### PR TITLE
Publica o build Vite no GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,12 @@ jobs:
       pages: write
 
     steps:
+      - name: Restringir publicação estável à main
+        if: inputs.source_run_id == '' && github.ref != 'refs/heads/main'
+        run: |
+          echo "A publicação estável só aceita a branch main." >&2
+          exit 1
+
       - name: Checkout
         if: inputs.source_run_id == ''
         uses: actions/checkout@v4
@@ -78,6 +84,14 @@ jobs:
               repo: context.repo.repo,
               run_id: Number('${{ inputs.source_run_id }}'),
             })
+            if (sourceRun.head_branch !== 'main') {
+              core.setFailed('A execução de origem não pertence à branch main.')
+              return
+            }
+            if (sourceRun.conclusion !== 'success') {
+              core.setFailed('A execução de origem não terminou com sucesso.')
+              return
+            }
             core.setOutput('head_sha', sourceRun.head_sha)
             core.setOutput('url', sourceRun.html_url)
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,9 +44,9 @@ jobs:
         if: inputs.source_run_id == ''
         run: npm ci
 
-      - name: Produzir artifact Vite
+      - name: Executar baseline operacional
         if: inputs.source_run_id == ''
-        run: npm run build:vite
+        run: npm run ci
 
       - name: Guardar artifact para rollback
         if: inputs.source_run_id == ''
@@ -55,7 +55,7 @@ jobs:
           name: vite-pages-dist
           path: dist
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
 
       - name: Recuperar artifact estável conhecido
         if: inputs.source_run_id != ''
@@ -67,6 +67,20 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.source_run_id }}
 
+      - name: Identificar commit da execução de origem
+        if: inputs.source_run_id != ''
+        id: rollback-origin
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: sourceRun } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: Number('${{ inputs.source_run_id }}'),
+            })
+            core.setOutput('head_sha', sourceRun.head_sha)
+            core.setOutput('url', sourceRun.html_url)
+
       - name: Configurar GitHub Pages
         uses: actions/configure-pages@v5
 
@@ -77,11 +91,13 @@ jobs:
 
       - name: Registrar origem do deploy
         env:
+          SOURCE_COMMIT: ${{ steps.rollback-origin.outputs.head_sha || github.sha }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id || github.run_id }}
+          SOURCE_RUN_URL: ${{ steps.rollback-origin.outputs.url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
         run: |
           echo "### Artifact pronto para publicação" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Commit solicitado: \`${GITHUB_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Execução de origem: \`${SOURCE_RUN_ID}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit de origem: \`${SOURCE_COMMIT}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Execução de origem: [\`${SOURCE_RUN_ID}\`](${SOURCE_RUN_URL})" >> "$GITHUB_STEP_SUMMARY"
           echo "- Artifact do Pages: \`github-pages\`" >> "$GITHUB_STEP_SUMMARY"
 
   deploy:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,102 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: ID da execução que produziu o artifact estável a republicar
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Preparar artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+
+    steps:
+      - name: Checkout
+        if: inputs.source_run_id == ''
+        uses: actions/checkout@v4
+
+      - name: Configurar Node.js
+        if: inputs.source_run_id == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Instalar pelo lockfile
+        if: inputs.source_run_id == ''
+        run: npm ci
+
+      - name: Produzir artifact Vite
+        if: inputs.source_run_id == ''
+        run: npm run build:vite
+
+      - name: Guardar artifact para rollback
+        if: inputs.source_run_id == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-pages-dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Recuperar artifact estável conhecido
+        if: inputs.source_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: vite-pages-dist
+          path: dist
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Configurar GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Empacotar artifact do Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Registrar origem do deploy
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source_run_id || github.run_id }}
+        run: |
+          echo "### Artifact pronto para publicação" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit solicitado: \`${GITHUB_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Execução de origem: \`${SOURCE_RUN_ID}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact do Pages: \`github-pages\`" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    name: Publicar
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Publicar no GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,9 @@ Exemplos:
 - `fix(keyboard): corrige repetição ao manter uma tecla pressionada`
 - `docs(agents): documenta convenções de commit`
 - `chore(deps): atualiza dependências de desenvolvimento`
+
+## Branches
+
+Use prefixos funcionais, como `feature/`, `fix/`, `docs/`, `refactor/` ou
+`chore/`, de acordo com a natureza principal da mudança. Nunca use como prefixo
+`codex`, `claude`, `gemini` nem o nome de qualquer agente.

--- a/config/public-base.mjs
+++ b/config/public-base.mjs
@@ -1,0 +1,3 @@
+export function publicBasePathFromHomepage(homepage) {
+    return new URL(homepage).pathname.replace(/\/$/, '')
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "react-scripts start",
     "start:vite": "vite",
     "build": "node scripts/build-legacy.mjs",
-    "build:vite": "vite build",
+    "build:vite": "vite build && node scripts/prepare-pages.mjs",
     "preview:vite": "vite preview",
     "test": "react-scripts test",
     "test:ci": "react-scripts test --watchAll=false && node --test scripts/*.test.mjs",

--- a/pages/404.html
+++ b/pages/404.html
@@ -10,7 +10,7 @@
     <main>
       <h1>Página não encontrada</h1>
       <p>O endereço informado não existe neste site.</p>
-      <p><a href="/den-braille-typewriter/">Voltar ao início do simulador</a></p>
+      <p><a href="{{BASE_PATH}}">Voltar ao início do simulador</a></p>
     </main>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Página não encontrada — Simulador de Máquina Braille</title>
+  </head>
+  <body>
+    <main>
+      <h1>Página não encontrada</h1>
+      <p>O endereço informado não existe neste site.</p>
+      <p><a href="/den-braille-typewriter/">Voltar ao início do simulador</a></p>
+    </main>
+  </body>
+</html>

--- a/scripts/pages-policy.test.mjs
+++ b/scripts/pages-policy.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import { createNotFoundPage } from './prepare-pages.mjs'
+import { publicBasePathFromHomepage } from '../config/public-base.mjs'
 
 const readProjectFile = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8')
 
@@ -28,8 +29,18 @@ test('oferece fallback 404 estático e acessível', async () => {
     assert.doesNotMatch(template, /den-braille-typewriter/)
 })
 
+test('deriva uma única base pública para build e fallback', () => {
+    assert.equal(
+        publicBasePathFromHomepage('https://example.test/outro-projeto/'),
+        '/outro-projeto'
+    )
+})
+
 test('publica o artifact Vite e permite republicar uma execução conhecida', async () => {
-    const workflow = await readProjectFile('.github/workflows/pages.yml')
+    const [workflow, artifactPreparation] = await Promise.all([
+        readProjectFile('.github/workflows/pages.yml'),
+        readProjectFile('scripts/prepare-pages.mjs'),
+    ])
 
     assert.match(workflow, /push:\s*\n\s*branches:\s*\[main\]/)
     assert.match(workflow, /workflow_dispatch:/)
@@ -40,7 +51,11 @@ test('publica o artifact Vite e permite republicar uma execução conhecida', as
     assert.match(workflow, /run-id:.*source_run_id/)
     assert.match(workflow, /getWorkflowRun/)
     assert.match(workflow, /head_sha/)
+    assert.match(workflow, /head_branch !== 'main'/)
+    assert.match(workflow, /conclusion !== 'success'/)
+    assert.match(workflow, /github\.ref != 'refs\/heads\/main'/)
     assert.match(workflow, /retention-days: 90/)
+    assert.match(artifactPreparation, /deployment-provenance\.json/)
     assert.match(workflow, /uses: actions\/upload-pages-artifact@v3/)
     assert.match(workflow, /uses: actions\/deploy-pages@v4/)
 })

--- a/scripts/pages-policy.test.mjs
+++ b/scripts/pages-policy.test.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
+import { createNotFoundPage } from './prepare-pages.mjs'
+
 const readProjectFile = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8')
 
 test('usa rotas por hash na composição publicada', async () => {
@@ -13,12 +15,17 @@ test('usa rotas por hash na composição publicada', async () => {
 })
 
 test('oferece fallback 404 estático e acessível', async () => {
-    const fallback = await readProjectFile('public/404.html')
+    const template = await readProjectFile('pages/404.html')
+    const notFoundPage = createNotFoundPage(
+        template,
+        'https://example.test/outro-projeto'
+    )
 
-    assert.match(fallback, /<html lang="pt-BR">/)
-    assert.match(fallback, /<title>Página não encontrada/)
-    assert.match(fallback, /<h1[^>]*>Página não encontrada<\/h1>/)
-    assert.match(fallback, /href="\/den-braille-typewriter\/"/)
+    assert.match(notFoundPage, /<html lang="pt-BR">/)
+    assert.match(notFoundPage, /<title>Página não encontrada/)
+    assert.match(notFoundPage, /<h1[^>]*>Página não encontrada<\/h1>/)
+    assert.match(notFoundPage, /href="\/outro-projeto\/"/)
+    assert.doesNotMatch(template, /den-braille-typewriter/)
 })
 
 test('publica o artifact Vite e permite republicar uma execução conhecida', async () => {
@@ -27,10 +34,13 @@ test('publica o artifact Vite e permite republicar uma execução conhecida', as
     assert.match(workflow, /push:\s*\n\s*branches:\s*\[main\]/)
     assert.match(workflow, /workflow_dispatch:/)
     assert.match(workflow, /source_run_id:/)
-    assert.match(workflow, /run: npm run build:vite/)
+    assert.match(workflow, /run: npm run ci/)
     assert.match(workflow, /name: vite-pages-dist/)
     assert.match(workflow, /path: dist/)
     assert.match(workflow, /run-id:.*source_run_id/)
+    assert.match(workflow, /getWorkflowRun/)
+    assert.match(workflow, /head_sha/)
+    assert.match(workflow, /retention-days: 90/)
     assert.match(workflow, /uses: actions\/upload-pages-artifact@v3/)
     assert.match(workflow, /uses: actions\/deploy-pages@v4/)
 })

--- a/scripts/pages-policy.test.mjs
+++ b/scripts/pages-policy.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readProjectFile = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+
+test('usa rotas por hash na composição publicada', async () => {
+    const bootstrap = await readProjectFile('src/bootstrap.jsx')
+
+    assert.match(bootstrap, /import \{ HashRouter, Route, Routes \}/)
+    assert.match(bootstrap, /<HashRouter>/)
+    assert.doesNotMatch(bootstrap, /<BrowserRouter/)
+})
+
+test('oferece fallback 404 estático e acessível', async () => {
+    const fallback = await readProjectFile('public/404.html')
+
+    assert.match(fallback, /<html lang="pt-BR">/)
+    assert.match(fallback, /<title>Página não encontrada/)
+    assert.match(fallback, /<h1[^>]*>Página não encontrada<\/h1>/)
+    assert.match(fallback, /href="\/den-braille-typewriter\/"/)
+})
+
+test('publica o artifact Vite e permite republicar uma execução conhecida', async () => {
+    const workflow = await readProjectFile('.github/workflows/pages.yml')
+
+    assert.match(workflow, /push:\s*\n\s*branches:\s*\[main\]/)
+    assert.match(workflow, /workflow_dispatch:/)
+    assert.match(workflow, /source_run_id:/)
+    assert.match(workflow, /run: npm run build:vite/)
+    assert.match(workflow, /name: vite-pages-dist/)
+    assert.match(workflow, /path: dist/)
+    assert.match(workflow, /run-id:.*source_run_id/)
+    assert.match(workflow, /uses: actions\/upload-pages-artifact@v3/)
+    assert.match(workflow, /uses: actions\/deploy-pages@v4/)
+})

--- a/scripts/prepare-pages.mjs
+++ b/scripts/prepare-pages.mjs
@@ -1,0 +1,23 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+export function createNotFoundPage(template, homepage) {
+    const basePath = `${new URL(homepage).pathname.replace(/\/$/, '')}/`
+
+    return template.replaceAll('{{BASE_PATH}}', basePath)
+}
+
+async function preparePagesArtifact() {
+    const [template, packageJson] = await Promise.all([
+        readFile(new URL('../pages/404.html', import.meta.url), 'utf8'),
+        readFile(new URL('../package.json', import.meta.url), 'utf8'),
+    ])
+    const { homepage } = JSON.parse(packageJson)
+    const fallback = createNotFoundPage(template, homepage)
+
+    await writeFile(new URL('../dist/404.html', import.meta.url), fallback)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    await preparePagesArtifact()
+}

--- a/scripts/prepare-pages.mjs
+++ b/scripts/prepare-pages.mjs
@@ -1,8 +1,10 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 
+import { publicBasePathFromHomepage } from '../config/public-base.mjs'
+
 export function createNotFoundPage(template, homepage) {
-    const basePath = `${new URL(homepage).pathname.replace(/\/$/, '')}/`
+    const basePath = `${publicBasePathFromHomepage(homepage)}/`
 
     return template.replaceAll('{{BASE_PATH}}', basePath)
 }
@@ -16,6 +18,18 @@ async function preparePagesArtifact() {
     const fallback = createNotFoundPage(template, homepage)
 
     await writeFile(new URL('../dist/404.html', import.meta.url), fallback)
+
+    if (process.env.GITHUB_SHA && process.env.GITHUB_RUN_ID) {
+        const provenance = {
+            commit: process.env.GITHUB_SHA,
+            repository: process.env.GITHUB_REPOSITORY,
+            runId: process.env.GITHUB_RUN_ID,
+        }
+        await writeFile(
+            new URL('../dist/deployment-provenance.json', import.meta.url),
+            `${JSON.stringify(provenance, null, 2)}\n`
+        )
+    }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/bootstrap.jsx
+++ b/src/bootstrap.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { HashRouter, Route, Routes } from 'react-router-dom'
 
 import './styles/index.css'
 import './vendors/bootstrap/css/bootstrap.min.css'
@@ -15,13 +15,13 @@ import Challenge from './views/modes/Challenge.tsx'
 ReactDOM.createRoot(document.getElementById('root')).render(
     <>
         <AudioProvider>
-            <BrowserRouter basename={process.env.PUBLIC_URL}>
+            <HashRouter>
                 <Routes>
                     <Route path='/' Component={Home} />
                     <Route path='/free' Component={Free} />
                     <Route path='/lessons' Component={Challenge} />
                 </Routes>
-            </BrowserRouter>
+            </HashRouter>
         </AudioProvider>
     </>
 )

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,8 +1,9 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import packageJson from './package.json' with { type: 'json' }
+import { publicBasePathFromHomepage } from './config/public-base.mjs'
 
-const publicBasePath = new URL(packageJson.homepage).pathname.replace(/\/$/, '')
+const publicBasePath = publicBasePathFromHomepage(packageJson.homepage)
 
 export default defineConfig({
     base: `${publicBasePath}/`,


### PR DESCRIPTION
## Resumo

- publica o artifact Vite no GitHub Pages somente após a baseline operacional verde
- usa rotas por hash e gera um fallback 404 acessível a partir da base pública única
- registra commit, execução e proveniência dentro do artifact publicado
- permite republicar por source_run_id um artifact bem-sucedido da main, retido por 90 dias
- documenta o padrão funcional de nomes de branches solicitado durante a implementação

## Validação

- npm run ci
- revisão de padrões: sem achados
- revisão da especificação: sem achados

Closes #29