### PR TITLE
Atualiza React para a versão de transição 18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
 
 ### Changed
 
+- React e React DOM passam para a versão de transição 18.3.1, mantendo a API
+  de raiz compatível com a próxima atualização principal.
 - Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
   caminho concorrente do Create React App foi removido.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
                 "bootstrap": "^5.3.3",
                 "fp-ts": "^2.16.2",
                 "immutable": "^5.0.0-beta.5",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1",
                 "react-router-dom": "^6.22.3",
                 "use-sound": "^4.0.1"
             },
@@ -3765,9 +3765,10 @@
             ]
         },
         "node_modules/react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -3776,15 +3777,16 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.0"
+                "scheduler": "^0.23.2"
             },
             "peerDependencies": {
-                "react": "^18.2.0"
+                "react": "^18.3.1"
             }
         },
         "node_modules/react-is": {
@@ -3966,9 +3968,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "bootstrap": "^5.3.3",
         "fp-ts": "^2.16.2",
         "immutable": "^5.0.0-beta.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3",
         "use-sound": "^4.0.1"
     },

--- a/scripts/react-version-policy.test.mjs
+++ b/scripts/react-version-policy.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const readProjectFile = (path) =>
+    readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+
+test('mantém React e renderer na linha de transição 18.3', async () => {
+    const packageJson = JSON.parse(await readProjectFile('package.json'))
+    const packageLock = JSON.parse(await readProjectFile('package-lock.json'))
+
+    assert.equal(packageJson.dependencies.react, '^18.3.1')
+    assert.equal(packageJson.dependencies['react-dom'], '^18.3.1')
+    assert.equal(packageLock.packages['node_modules/react'].version, '18.3.1')
+    assert.equal(
+        packageLock.packages['node_modules/react-dom'].version,
+        '18.3.1',
+    )
+})
+
+test('usa a API de raiz concorrente compatível com a próxima versão', async () => {
+    const bootstrap = await readProjectFile('src/bootstrap.jsx')
+
+    assert.match(bootstrap, /from 'react-dom\/client'/)
+    assert.match(bootstrap, /\.createRoot\(/)
+    assert.doesNotMatch(
+        bootstrap,
+        /ReactDOM\.render|ReactDOM\.hydrate|findDOMNode|unmountComponentAtNode/,
+    )
+})


### PR DESCRIPTION
## Resumo

- atualiza React e React DOM em conjunto para 18.3.1
- preserva a API de raiz `createRoot` compatível com a próxima versão principal
- adiciona uma política de CI para impedir regressão de versão e APIs descontinuadas
- registra a transição no changelog

## Validação

- `npm ci`
- `npm run ci`
- `npm ls react react-dom --all`
- `git diff --check`

Closes #33