### PR TITLE
Proteger as fronteiras entre capacidades

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
         "format": "prettier --check .",
         "lint": "node scripts/check-lint-baseline.mjs",
         "typecheck": "tsc --noEmit",
+        "architecture": "node scripts/check-architecture.mjs",
         "test": "vitest",
         "test:ci": "vitest run && node --test scripts/*.test.mjs",
         "audit": "node scripts/check-audit-baseline.mjs",
-        "ci": "npm run format && npm run lint && npm run typecheck && npm run test:ci && npm run build && npm run audit"
+        "ci": "npm run format && npm run lint && npm run typecheck && npm run architecture && npm run test:ci && npm run build && npm run audit"
     },
     "devDependencies": {
         "@testing-library/dom": "^10.4.1",

--- a/scripts/architecture-policy.test.mjs
+++ b/scripts/architecture-policy.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const createProject = async (files) => {
+    const root = await mkdtemp(join(tmpdir(), 'den-architecture-'))
+
+    await Promise.all(
+        Object.entries(files).map(async ([relativePath, contents]) => {
+            const absolutePath = join(root, 'src', relativePath)
+            await mkdir(join(absolutePath, '..'), { recursive: true })
+            await writeFile(absolutePath, contents)
+        }),
+    )
+
+    return root
+}
+
+const runArchitectureCheck = (root) =>
+    spawnSync(process.execPath, ['scripts/check-architecture.mjs', root], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+    })
+
+test('rejeita import externo de detalhe interno de uma capacidade', async () => {
+    const root = await createProject({
+        'braille/internal/cell.ts': 'export const cell = 1',
+        'session/public.ts':
+            "import { cell } from '../braille/internal/cell'\nexport { cell }",
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 1)
+    assert.match(
+        result.stderr,
+        /session\/public\.ts importa detalhe interno de braille/,
+    )
+})
+
+test('aceita interfaces públicas como entrada dos consumidores', async () => {
+    const root = await createProject({
+        'braille/public.js': 'export const cell = 1',
+        'session/public.ts':
+            "import { cell } from '../braille/public.js'\nexport { cell }",
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /Fronteiras arquiteturais preservadas/)
+})
+
+test('rejeita import dinâmico de detalhe interno', async () => {
+    const root = await createProject({
+        'feedback/internal/catalog.ts': 'export const catalog = {}',
+        'ui/public.ts':
+            "export const catalog = import('../feedback/internal/catalog')",
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 1)
+    assert.match(
+        result.stderr,
+        /ui\/public\.ts importa detalhe interno de feedback/,
+    )
+})
+
+test('rejeita detalhe interno consumido pelo código legado', async () => {
+    const root = await createProject({
+        'braille/machine/state.ts': 'export const state = {}',
+        'components/Legacy.tsx':
+            "import { state } from '../braille/machine/state'\nexport { state }",
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 1)
+    assert.match(
+        result.stderr,
+        /components\/Legacy\.tsx importa detalhe interno de braille/,
+    )
+})
+
+test('rejeita ciclo entre capacidades por suas interfaces públicas', async () => {
+    const root = await createProject({
+        'braille/public.ts': "export { session } from '../session/public'",
+        'session/public.ts': "export { braille } from '../braille/public'",
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 1)
+    assert.match(
+        result.stderr,
+        /Ciclo entre capacidades: braille -> session -> braille/,
+    )
+})

--- a/scripts/architecture-policy.test.mjs
+++ b/scripts/architecture-policy.test.mjs
@@ -100,3 +100,15 @@ test('rejeita ciclo entre capacidades por suas interfaces públicas', async () =
         /Ciclo entre capacidades: braille -> session -> braille/,
     )
 })
+
+test('rejeita dependência contrária à direção documentada', async () => {
+    const root = await createProject({
+        'braille/public.ts': "export { session } from '../session/public'",
+        'session/public.ts': 'export const session = {}',
+    })
+
+    const result = runArchitectureCheck(root)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /braille não pode depender de session/)
+})

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -13,6 +13,34 @@ const CAPABILITIES = new Set([
     'ui',
 ])
 const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.ts', '.tsx'])
+const ALLOWED_DEPENDENCIES = new Map([
+    [
+        'app',
+        new Set([
+            'braille',
+            'experiences',
+            'feedback',
+            'preferences',
+            'session',
+            'ui',
+        ]),
+    ],
+    ['braille', new Set()],
+    ['experiences', new Set(['braille', 'preferences', 'session'])],
+    ['feedback', new Set(['braille', 'experiences', 'preferences', 'session'])],
+    ['preferences', new Set()],
+    ['session', new Set(['braille', 'preferences'])],
+    [
+        'ui',
+        new Set([
+            'braille',
+            'experiences',
+            'feedback',
+            'preferences',
+            'session',
+        ]),
+    ],
+])
 
 const listSourceFiles = async (directory) => {
     const entries = await readdir(directory, { withFileTypes: true })
@@ -94,6 +122,16 @@ export const findArchitectureViolations = async (projectRoot) => {
                     dependencies.get(importerCapability) ?? new Set()
                 capabilityDependencies.add(importedCapability)
                 dependencies.set(importerCapability, capabilityDependencies)
+
+                if (
+                    !ALLOWED_DEPENDENCIES.get(importerCapability).has(
+                        importedCapability,
+                    )
+                ) {
+                    violations.push(
+                        `${importerPath}: ${importerCapability} não pode depender de ${importedCapability}`,
+                    )
+                }
             }
 
             if (!/^public(?:\.[cm]?[jt]sx?)?$/.test(internalPath.join('/'))) {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -3,15 +3,6 @@ import { dirname, extname, relative, resolve, sep } from 'node:path'
 import process from 'node:process'
 import ts from 'typescript'
 
-const CAPABILITIES = new Set([
-    'app',
-    'braille',
-    'experiences',
-    'feedback',
-    'preferences',
-    'session',
-    'ui',
-])
 const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.ts', '.tsx'])
 const ALLOWED_DEPENDENCIES = new Map([
     [
@@ -111,23 +102,21 @@ export const findArchitectureViolations = async (projectRoot) => {
                 importedPath.split('/')
 
             if (
-                !CAPABILITIES.has(importedCapability) ||
+                !ALLOWED_DEPENDENCIES.has(importedCapability) ||
                 importedCapability === importerCapability
             ) {
                 continue
             }
 
-            if (CAPABILITIES.has(importerCapability)) {
+            const allowedDependencies =
+                ALLOWED_DEPENDENCIES.get(importerCapability)
+            if (allowedDependencies) {
                 const capabilityDependencies =
                     dependencies.get(importerCapability) ?? new Set()
                 capabilityDependencies.add(importedCapability)
                 dependencies.set(importerCapability, capabilityDependencies)
 
-                if (
-                    !ALLOWED_DEPENDENCIES.get(importerCapability).has(
-                        importedCapability,
-                    )
-                ) {
+                if (!allowedDependencies.has(importedCapability)) {
                     violations.push(
                         `${importerPath}: ${importerCapability} não pode depender de ${importedCapability}`,
                     )

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1,0 +1,151 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, extname, relative, resolve, sep } from 'node:path'
+import process from 'node:process'
+import ts from 'typescript'
+
+const CAPABILITIES = new Set([
+    'app',
+    'braille',
+    'experiences',
+    'feedback',
+    'preferences',
+    'session',
+    'ui',
+])
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.ts', '.tsx'])
+
+const listSourceFiles = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true })
+    const nested = await Promise.all(
+        entries.map((entry) => {
+            const path = resolve(directory, entry.name)
+            return entry.isDirectory() ? listSourceFiles(path) : [path]
+        }),
+    )
+
+    return nested.flat().filter((path) => SOURCE_EXTENSIONS.has(extname(path)))
+}
+
+const importedModules = (source, fileName) => {
+    const sourceFile = ts.createSourceFile(
+        fileName,
+        source,
+        ts.ScriptTarget.Latest,
+        true,
+    )
+    const modules = []
+
+    const visit = (node) => {
+        if (
+            (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+            node.moduleSpecifier &&
+            ts.isStringLiteral(node.moduleSpecifier)
+        ) {
+            modules.push(node.moduleSpecifier.text)
+        }
+        if (
+            ts.isCallExpression(node) &&
+            node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+            node.arguments.length === 1 &&
+            ts.isStringLiteral(node.arguments[0])
+        ) {
+            modules.push(node.arguments[0].text)
+        }
+        ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+    return modules
+}
+
+const normalizedRelativePath = (from, to) =>
+    relative(from, to).split(sep).join('/')
+
+export const findArchitectureViolations = async (projectRoot) => {
+    const sourceRoot = resolve(projectRoot, 'src')
+    const files = await listSourceFiles(sourceRoot)
+    const violations = []
+    const dependencies = new Map()
+
+    for (const file of files) {
+        const importerPath = normalizedRelativePath(sourceRoot, file)
+        const importerCapability = importerPath.split('/')[0]
+
+        const source = await readFile(file, 'utf8')
+        for (const moduleSpecifier of importedModules(source, file)) {
+            if (!moduleSpecifier.startsWith('.')) continue
+
+            const importedPath = normalizedRelativePath(
+                sourceRoot,
+                resolve(dirname(file), moduleSpecifier),
+            )
+            const [importedCapability, ...internalPath] =
+                importedPath.split('/')
+
+            if (
+                !CAPABILITIES.has(importedCapability) ||
+                importedCapability === importerCapability
+            ) {
+                continue
+            }
+
+            if (CAPABILITIES.has(importerCapability)) {
+                const capabilityDependencies =
+                    dependencies.get(importerCapability) ?? new Set()
+                capabilityDependencies.add(importedCapability)
+                dependencies.set(importerCapability, capabilityDependencies)
+            }
+
+            if (!/^public(?:\.[cm]?[jt]sx?)?$/.test(internalPath.join('/'))) {
+                violations.push(
+                    `${importerPath} importa detalhe interno de ${importedCapability}: ${moduleSpecifier}`,
+                )
+            }
+        }
+    }
+
+    const visited = new Set()
+    const active = new Set()
+    const path = []
+
+    const findCycle = (capability) => {
+        if (active.has(capability)) {
+            const cycleStart = path.indexOf(capability)
+            return [...path.slice(cycleStart), capability]
+        }
+        if (visited.has(capability)) return undefined
+
+        active.add(capability)
+        path.push(capability)
+        for (const dependency of dependencies.get(capability) ?? []) {
+            const cycle = findCycle(dependency)
+            if (cycle) return cycle
+        }
+        path.pop()
+        active.delete(capability)
+        visited.add(capability)
+        return undefined
+    }
+
+    for (const capability of [...dependencies.keys()].sort()) {
+        const cycle = findCycle(capability)
+        if (cycle) {
+            violations.push(`Ciclo entre capacidades: ${cycle.join(' -> ')}`)
+            break
+        }
+    }
+
+    return violations
+}
+
+const projectRoot = resolve(process.argv[2] ?? process.cwd())
+const violations = await findArchitectureViolations(projectRoot)
+
+if (violations.length > 0) {
+    process.stderr.write(
+        `Fronteiras arquiteturais violadas:\n- ${violations.join('\n- ')}\n`,
+    )
+    process.exitCode = 1
+} else {
+    process.stdout.write('Fronteiras arquiteturais preservadas.\n')
+}

--- a/scripts/quality-guardrails-policy.test.mjs
+++ b/scripts/quality-guardrails-policy.test.mjs
@@ -9,6 +9,7 @@ const verificationCommands = [
     'format',
     'lint',
     'typecheck',
+    'architecture',
     'test:ci',
     'build',
     'audit',


### PR DESCRIPTION
## Resumo

- adiciona um guardrail arquitetural baseado no parser TypeScript
- rejeita imports externos fora das interfaces públicas, ciclos e direções proibidas
- integra a verificação à interface operacional e à CI

## Validação

- 
added 258 packages, and audited 259 packages in 2s

64 packages are looking for funding
  run `npm fund` for details

11 vulnerabilities (2 moderate, 9 high)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
- Checking formatting...
All matched files use Prettier code style!
11 falhas herdadas de lint permanecem isoladas.
Fronteiras arquiteturais preservadas.

 RUN  v4.1.11 /home/gomesh/Documents/GitHub/den-braille-typewriter


 Test Files  3 passed (3)
      Tests  21 passed (21)
   Start at  16:21:48
   Duration  1.22s (transform 159ms, setup 157ms, import 281ms, tests 515ms, environment 1.06s)

✔ rejeita import externo de detalhe interno de uma capacidade (329.131724ms)
✔ aceita interfaces públicas como entrada dos consumidores (282.50029ms)
✔ rejeita import dinâmico de detalhe interno (272.921544ms)
✔ rejeita detalhe interno consumido pelo código legado (276.94816ms)
✔ rejeita ciclo entre capacidades por suas interfaces públicas (259.578465ms)
✔ rejeita dependência contrária à direção documentada (264.307805ms)
✔ aceita advisories herdados e ignora referências via por nome (2.699105ms)
✔ rejeita advisory crítico ou alto que não pertence à baseline (0.34509ms)
✔ rejeita advisory herdado quando passa a afetar outro pacote (0.252566ms)
✔ rejeita aumento da contagem mesmo quando os IDs são conhecidos (0.238269ms)
✔ informa quando uma ocorrência herdada foi resolvida (0.31841ms)
✔ aceita somente os avisos herdados registrados (2.544203ms)
✔ separa uma nova falha da baseline herdada (0.349789ms)
✔ informa quando uma falha herdada foi resolvida (0.239942ms)
✔ rejeita uma nova ocorrência idêntica no mesmo arquivo (1.15176ms)
✔ usa rotas por hash na composição publicada (6.804249ms)
✔ oferece fallback 404 estático e acessível (1.821502ms)
✔ deriva uma única base pública para build e fallback (0.448886ms)
✔ publica o artifact Vite e permite republicar uma execução conhecida (2.251212ms)
✔ expõe somente os comandos canônicos do Vite (6.99565ms)
✔ não mantém dependências, scripts ou configurações do CRA (2.095858ms)
✔ CI exercita o build canônico uma única vez (1.346847ms)
✔ expõe comandos estáveis que apenas verificam o projeto (6.643045ms)
✔ CI executa cada guardrail aprovado uma única vez (1.876224ms)
✔ exceções registram governança e permanecem dentro do prazo (5.538334ms)
✔ mantém React e renderer na baseline 19.2 aprovada (8.993964ms)
✔ usa a API de raiz concorrente compatível com a próxima versão (1.531175ms)
✔ mantém somente TypeScript 6 na árvore instalada (10.810777ms)
✔ executa o typecheck estrito sem emitir arquivos (3.379076ms)
✔ exige justificativa localizada para supressões TypeScript (1.436807ms)
ℹ tests 30
ℹ suites 0
ℹ pass 30
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1755.8086
vite v8.2.2 building client environment for production...
transforming...
✓ 114 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                      0.88 kB │ gzip:   0.45 kB
dist/assets/braille_v1_by_xchristaox-MpOSh7Ez.ttf   47.18 kB
dist/assets/index-N5p0-XK8.css                     236.62 kB │ gzip:  32.47 kB
dist/assets/index-CUu1okq-.js                      448.05 kB │ gzip: 134.65 kB

✓ built in 477ms
Vulnerabilidades de produção: 0 críticas, 4 altas, 1 moderadas e 0 baixas.
- revisão Standards: 0 achados
- revisão Spec: 0 achados

Closes #36