### PR TITLE
Preserva Impressões de cela na Grade Braille

### DIFF
--- a/src/braille/README.md
+++ b/src/braille/README.md
@@ -3,9 +3,11 @@
 ## Responsabilidade
 
 Esta capacidade concentra regras Braille independentes de experiência,
-dispositivo e apresentação. Neste primeiro corte, `machine` implementa o Motor da
-máquina Braille: recebe `MachineIntent` (Intenção da máquina) e produz estado,
-snapshot e eventos semânticos por uma transição pura.
+dispositivo e apresentação. O módulo `machine` implementa o Motor da máquina
+Braille: recebe `MachineIntent` (Intenção da máquina) e produz estado, snapshot e
+eventos semânticos por uma transição pura. O módulo `document` preserva
+`CellImpression` (Impressão de cela) em posições explícitas de uma Grade Braille
+esparsa, sem atribuir texto às celas.
 
 Não pertencem ao Motor: interpretação textual, Documento Braille, Sessão de
 digitação, origem física dos controles, React, DOM, áudio ou qualquer efeito
@@ -20,6 +22,10 @@ Consumidores e testes importam somente `braille/public.ts`. A interface oferece:
 - `createEngineState` para iniciar uma captura sem controles ativos;
 - `applyIntent` como única transição do Motor;
 - os tipos das intenções, operações, eventos, estado, snapshot e resultado.
+- `createCellImpression` para distinguir pontos elevados, vestígios de pontos
+  apagados e espaço explícito;
+- `createGridPosition`, `createBrailleDocument`, `recordCellImpression` e
+  `getCellImpression` para registrar e consultar a produção por posição.
 
 Exemplo:
 
@@ -58,6 +64,23 @@ semântico em inglês, destinado ao consumo técnico e não à apresentação di
 Estado, snapshot, eventos e valores são serializáveis e não devem ser alterados
 pelo consumidor.
 
+## Documento Braille
+
+- `GridPosition` usa linhas e colunas inteiras, zero-based e não negativas.
+- Uma posição ausente em `BrailleDocument` nunca foi utilizada.
+- Uma `CellImpression` vazia ocupa uma posição e registra um espaço explícito.
+- `erasedDots` preserva vestígios físicos separadamente dos pontos elevados em
+  `cell`; o mesmo ponto não pode ocupar os dois estados.
+- `recordCellImpression` é imutável e rejeita uma posição já utilizada com
+  `position-already-used`. Edição e sobrescrita pertencem ao corte posterior.
+- O documento contém somente geometria Braille. Texto, caracteres e significado
+  pertencem à Interpretação Braille e não fazem parte desta interface.
+
+Coordenadas inválidas e sobreposição entre ponto elevado e apagado produzem
+`RangeError`. Tentativas válidas que conflitam com o estado do documento devolvem
+um `DocumentResult` (Resultado do Documento) com erro estruturado e preservam o
+estado anterior.
+
 ## Dependências e adapters
 
 O Motor usa somente TypeScript e não depende de outras capacidades do produto.
@@ -68,15 +91,17 @@ texto localizado quando houver comunicação com a pessoa usuária.
 
 ## Estratégia de testes
 
-Os exemplos e invariantes são exercitados em `machine.test.ts` exclusivamente
-por `braille/public.ts`. Os testes observam resultados da transição e não acessam
-arquivos internos nem efeitos de plataforma. Código e descrições dos testes usam
-inglês; este documento permanece em português.
+Os exemplos e invariantes são exercitados em `machine.test.ts` e
+`document.test.ts` exclusivamente por `braille/public.ts`. Os testes observam
+resultados públicos e não acessam arquivos internos nem efeitos de plataforma.
+Código e descrições dos testes usam inglês; este documento permanece em
+português.
 
 ## Referências
 
 - `CONTEXT.md`
 - `docs/adr/0001-motor-braille-como-transicao-pura.md`
+- `docs/adr/0002-documento-braille-e-grafia-contextual.md`
 - `docs/adr/0007-testes-por-interfaces-e-guardrails-continuos.md`
 - `docs/adr/0011-arquitetura-por-capacidades-e-interfaces-publicas.md`
 - `docs/adr/0013-ingles-nos-contratos-tecnicos.md`

--- a/src/braille/README.md
+++ b/src/braille/README.md
@@ -5,9 +5,10 @@
 Esta capacidade concentra regras Braille independentes de experiência,
 dispositivo e apresentação. O módulo `machine` implementa o Motor da máquina
 Braille: recebe `MachineIntent` (Intenção da máquina) e produz estado, snapshot e
-eventos semânticos por uma transição pura. O módulo `document` preserva
-`CellImpression` (Impressão de cela) em posições explícitas de uma Grade Braille
-esparsa, sem atribuir texto às celas.
+eventos semânticos por uma transição pura. O módulo `document` inicia a fundação
+do Documento Braille ao preservar `CellImpression` (Impressão de cela) em
+posições explícitas de uma `BrailleGrid` (Grade Braille) esparsa, sem atribuir
+texto às celas.
 
 Não pertencem ao Motor: interpretação textual, Documento Braille, Sessão de
 digitação, origem física dos controles, React, DOM, áudio ou qualquer efeito
@@ -24,7 +25,7 @@ Consumidores e testes importam somente `braille/public.ts`. A interface oferece:
 - os tipos das intenções, operações, eventos, estado, snapshot e resultado.
 - `createCellImpression` para distinguir pontos elevados, vestígios de pontos
   apagados e espaço explícito;
-- `createGridPosition`, `createBrailleDocument`, `recordCellImpression` e
+- `createGridPosition`, `createBrailleGrid`, `recordCellImpression` e
   `getCellImpression` para registrar e consultar a produção por posição.
 
 Exemplo:
@@ -64,22 +65,27 @@ semântico em inglês, destinado ao consumo técnico e não à apresentação di
 Estado, snapshot, eventos e valores são serializáveis e não devem ser alterados
 pelo consumidor.
 
-## Documento Braille
+## Fundação do Documento Braille
 
 - `GridPosition` usa linhas e colunas inteiras, zero-based e não negativas.
-- Uma posição ausente em `BrailleDocument` nunca foi utilizada.
+- Uma posição ausente em `BrailleGrid` nunca foi utilizada.
 - Uma `CellImpression` vazia ocupa uma posição e registra um espaço explícito.
 - `erasedDots` preserva vestígios físicos separadamente dos pontos elevados em
   `cell`; o mesmo ponto não pode ocupar os dois estados.
 - `recordCellImpression` é imutável e rejeita uma posição já utilizada com
   `position-already-used`. Edição e sobrescrita pertencem ao corte posterior.
-- O documento contém somente geometria Braille. Texto, caracteres e significado
+- A grade contém somente geometria Braille. Texto, caracteres e significado
   pertencem à Interpretação Braille e não fazem parte desta interface.
+
+Este corte não publica um `BrailleDocument` parcial. A #39 comporá a Grade
+Braille com Configuração de papel, Folhas Braille ou Papel contínuo virtual,
+Posição de edição e Posição de revisão, conforme a ADR 0002. Assim, a conclusão
+do Documento não exigirá quebrar a interface da grade criada aqui.
 
 Coordenadas inválidas e sobreposição entre ponto elevado e apagado produzem
 `RangeError`. Tentativas válidas que conflitam com o estado do documento devolvem
-um `DocumentResult` (Resultado do Documento) com erro estruturado e preservam o
-estado anterior.
+um `GridResult` (Resultado da Grade) com erro estruturado e preservam o estado
+anterior.
 
 ## Dependências e adapters
 

--- a/src/braille/document.test.ts
+++ b/src/braille/document.test.ts
@@ -4,7 +4,7 @@ import {
     applyIntent,
     createBrailleCell,
     createBrailleDot,
-    createBrailleDocument,
+    createBrailleGrid,
     createCellImpression,
     createEngineState,
     createGridPosition,
@@ -38,7 +38,7 @@ describe('cell impression', () => {
     })
 })
 
-describe('Braille document', () => {
+describe('Braille document grid', () => {
     test('records a cell confirmed by the engine without textual conversion', () => {
         const dot = createBrailleDot(1)
         const pressed = applyIntent(createEngineState(), {
@@ -58,14 +58,14 @@ describe('Braille document', () => {
         }
 
         const result = recordCellImpression(
-            createBrailleDocument(),
+            createBrailleGrid(),
             createGridPosition(0, 0),
             createCellImpression(event.operation.cell),
         )
 
         expect(result).toMatchObject({
             status: 'recorded',
-            document: {
+            grid: {
                 impressions: [
                     {
                         impression: {
@@ -80,21 +80,17 @@ describe('Braille document', () => {
 
     test('records a confirmed cell at an explicit grid position', () => {
         const position = createGridPosition(2, 3)
-        const unusedDocument = createBrailleDocument()
+        const unusedGrid = createBrailleGrid()
         const impression = createCellImpression(createBrailleCell([1, 4]))
 
-        expect(getCellImpression(unusedDocument, position)).toBeUndefined()
+        expect(getCellImpression(unusedGrid, position)).toBeUndefined()
 
-        const result = recordCellImpression(
-            unusedDocument,
-            position,
-            impression,
-        )
+        const result = recordCellImpression(unusedGrid, position, impression)
 
         expect(result).toMatchObject({ status: 'recorded' })
         if (result.status !== 'recorded') throw new Error('Expected recording')
-        expect(getCellImpression(result.document, position)).toEqual(impression)
-        expect(getCellImpression(unusedDocument, position)).toBeUndefined()
+        expect(getCellImpression(result.grid, position)).toEqual(impression)
+        expect(getCellImpression(unusedGrid, position)).toBeUndefined()
     })
 
     test('preserves explicit space and erased traces as occupied positions', () => {
@@ -102,7 +98,7 @@ describe('Braille document', () => {
         const tracedPosition = createGridPosition(0, 1)
         const unusedPosition = createGridPosition(0, 2)
         const emptyResult = recordCellImpression(
-            createBrailleDocument(),
+            createBrailleGrid(),
             emptyPosition,
             createCellImpression(),
         )
@@ -110,7 +106,7 @@ describe('Braille document', () => {
             throw new Error('Expected explicit space recording')
         }
         const tracedResult = recordCellImpression(
-            emptyResult.document,
+            emptyResult.grid,
             tracedPosition,
             createCellImpression(createBrailleCell(), [createBrailleDot(3)]),
         )
@@ -118,14 +114,16 @@ describe('Braille document', () => {
             throw new Error('Expected erased trace recording')
         }
 
-        expect(getCellImpression(tracedResult.document, emptyPosition)).toEqual(
-            { cell: { dots: [] }, erasedDots: [] },
-        )
+        expect(getCellImpression(tracedResult.grid, emptyPosition)).toEqual({
+            cell: { dots: [] },
+            erasedDots: [],
+        })
+        expect(getCellImpression(tracedResult.grid, tracedPosition)).toEqual({
+            cell: { dots: [] },
+            erasedDots: [3],
+        })
         expect(
-            getCellImpression(tracedResult.document, tracedPosition),
-        ).toEqual({ cell: { dots: [] }, erasedDots: [3] })
-        expect(
-            getCellImpression(tracedResult.document, unusedPosition),
+            getCellImpression(tracedResult.grid, unusedPosition),
         ).toBeUndefined()
     })
 
@@ -133,7 +131,7 @@ describe('Braille document', () => {
         const position = createGridPosition(1, 1)
         const firstImpression = createCellImpression(createBrailleCell([1]))
         const firstResult = recordCellImpression(
-            createBrailleDocument(),
+            createBrailleGrid(),
             position,
             firstImpression,
         )
@@ -142,17 +140,17 @@ describe('Braille document', () => {
         }
 
         const rejected = recordCellImpression(
-            firstResult.document,
+            firstResult.grid,
             position,
             createCellImpression(createBrailleCell([2])),
         )
 
         expect(rejected).toEqual({
             status: 'rejected',
-            document: firstResult.document,
+            grid: firstResult.grid,
             error: { type: 'position-already-used', position },
         })
-        expect(getCellImpression(firstResult.document, position)).toEqual(
+        expect(getCellImpression(firstResult.grid, position)).toEqual(
             firstImpression,
         )
     })
@@ -166,18 +164,18 @@ describe('Braille document', () => {
         )
     })
 
-    test('keeps document state immutable and serializable', () => {
+    test('keeps grid state immutable and serializable', () => {
         const result = recordCellImpression(
-            createBrailleDocument(),
+            createBrailleGrid(),
             createGridPosition(0, 0),
             createCellImpression(createBrailleCell([1, 2])),
         )
         if (result.status !== 'recorded') throw new Error('Expected recording')
 
         expect(Object.isFrozen(result)).toBe(true)
-        expect(Object.isFrozen(result.document)).toBe(true)
-        expect(Object.isFrozen(result.document.impressions)).toBe(true)
-        expect(JSON.parse(JSON.stringify(result.document))).toEqual({
+        expect(Object.isFrozen(result.grid)).toBe(true)
+        expect(Object.isFrozen(result.grid.impressions)).toBe(true)
+        expect(JSON.parse(JSON.stringify(result.grid))).toEqual({
             impressions: [
                 {
                     position: { row: 0, column: 0 },

--- a/src/braille/document.test.ts
+++ b/src/braille/document.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+    applyIntent,
+    createBrailleCell,
+    createBrailleDot,
+    createBrailleDocument,
+    createCellImpression,
+    createEngineState,
+    createGridPosition,
+    getCellImpression,
+    recordCellImpression,
+} from './public'
+
+describe('cell impression', () => {
+    test('distinguishes raised dots, erased traces and explicit space', () => {
+        const impression = createCellImpression(createBrailleCell([1, 4]), [
+            createBrailleDot(2),
+            createBrailleDot(5),
+        ])
+
+        expect(impression).toEqual({
+            cell: { dots: [1, 4] },
+            erasedDots: [2, 5],
+        })
+        expect(createCellImpression()).toEqual({
+            cell: { dots: [] },
+            erasedDots: [],
+        })
+        expect(Object.isFrozen(impression)).toBe(true)
+        expect(Object.isFrozen(impression.erasedDots)).toBe(true)
+    })
+
+    test('rejects a dot that is both raised and erased', () => {
+        expect(() =>
+            createCellImpression(createBrailleCell([1]), [createBrailleDot(1)]),
+        ).toThrowError('A Braille dot cannot be both raised and erased: 1')
+    })
+})
+
+describe('Braille document', () => {
+    test('records a cell confirmed by the engine without textual conversion', () => {
+        const dot = createBrailleDot(1)
+        const pressed = applyIntent(createEngineState(), {
+            type: 'press',
+            control: { type: 'dot', dot },
+        })
+        const released = applyIntent(pressed.state, {
+            type: 'release',
+            control: { type: 'dot', dot },
+        })
+        const event = released.events[0]
+        if (
+            event?.type !== 'operation-produced' ||
+            event.operation.type !== 'confirm-cell'
+        ) {
+            throw new Error('Expected a confirmed cell')
+        }
+
+        const result = recordCellImpression(
+            createBrailleDocument(),
+            createGridPosition(0, 0),
+            createCellImpression(event.operation.cell),
+        )
+
+        expect(result).toMatchObject({
+            status: 'recorded',
+            document: {
+                impressions: [
+                    {
+                        impression: {
+                            cell: { dots: [1] },
+                            erasedDots: [],
+                        },
+                    },
+                ],
+            },
+        })
+    })
+
+    test('records a confirmed cell at an explicit grid position', () => {
+        const position = createGridPosition(2, 3)
+        const unusedDocument = createBrailleDocument()
+        const impression = createCellImpression(createBrailleCell([1, 4]))
+
+        expect(getCellImpression(unusedDocument, position)).toBeUndefined()
+
+        const result = recordCellImpression(
+            unusedDocument,
+            position,
+            impression,
+        )
+
+        expect(result).toMatchObject({ status: 'recorded' })
+        if (result.status !== 'recorded') throw new Error('Expected recording')
+        expect(getCellImpression(result.document, position)).toEqual(impression)
+        expect(getCellImpression(unusedDocument, position)).toBeUndefined()
+    })
+
+    test('preserves explicit space and erased traces as occupied positions', () => {
+        const emptyPosition = createGridPosition(0, 0)
+        const tracedPosition = createGridPosition(0, 1)
+        const unusedPosition = createGridPosition(0, 2)
+        const emptyResult = recordCellImpression(
+            createBrailleDocument(),
+            emptyPosition,
+            createCellImpression(),
+        )
+        if (emptyResult.status !== 'recorded') {
+            throw new Error('Expected explicit space recording')
+        }
+        const tracedResult = recordCellImpression(
+            emptyResult.document,
+            tracedPosition,
+            createCellImpression(createBrailleCell(), [createBrailleDot(3)]),
+        )
+        if (tracedResult.status !== 'recorded') {
+            throw new Error('Expected erased trace recording')
+        }
+
+        expect(getCellImpression(tracedResult.document, emptyPosition)).toEqual(
+            { cell: { dots: [] }, erasedDots: [] },
+        )
+        expect(
+            getCellImpression(tracedResult.document, tracedPosition),
+        ).toEqual({ cell: { dots: [] }, erasedDots: [3] })
+        expect(
+            getCellImpression(tracedResult.document, unusedPosition),
+        ).toBeUndefined()
+    })
+
+    test('exposes a rejection without replacing an occupied position', () => {
+        const position = createGridPosition(1, 1)
+        const firstImpression = createCellImpression(createBrailleCell([1]))
+        const firstResult = recordCellImpression(
+            createBrailleDocument(),
+            position,
+            firstImpression,
+        )
+        if (firstResult.status !== 'recorded') {
+            throw new Error('Expected initial recording')
+        }
+
+        const rejected = recordCellImpression(
+            firstResult.document,
+            position,
+            createCellImpression(createBrailleCell([2])),
+        )
+
+        expect(rejected).toEqual({
+            status: 'rejected',
+            document: firstResult.document,
+            error: { type: 'position-already-used', position },
+        })
+        expect(getCellImpression(firstResult.document, position)).toEqual(
+            firstImpression,
+        )
+    })
+
+    test('rejects invalid zero-based grid positions', () => {
+        expect(() => createGridPosition(-1, 0)).toThrowError(
+            'Invalid grid row: -1',
+        )
+        expect(() => createGridPosition(0, 1.5)).toThrowError(
+            'Invalid grid column: 1.5',
+        )
+    })
+
+    test('keeps document state immutable and serializable', () => {
+        const result = recordCellImpression(
+            createBrailleDocument(),
+            createGridPosition(0, 0),
+            createCellImpression(createBrailleCell([1, 2])),
+        )
+        if (result.status !== 'recorded') throw new Error('Expected recording')
+
+        expect(Object.isFrozen(result)).toBe(true)
+        expect(Object.isFrozen(result.document)).toBe(true)
+        expect(Object.isFrozen(result.document.impressions)).toBe(true)
+        expect(JSON.parse(JSON.stringify(result.document))).toEqual({
+            impressions: [
+                {
+                    position: { row: 0, column: 0 },
+                    impression: { cell: { dots: [1, 2] }, erasedDots: [] },
+                },
+            ],
+        })
+    })
+})

--- a/src/braille/document/document.ts
+++ b/src/braille/document/document.ts
@@ -1,0 +1,83 @@
+import type { CellImpression } from './impression'
+
+export type GridPosition = Readonly<{
+    row: number
+    column: number
+}>
+
+export type PositionedCellImpression = Readonly<{
+    position: GridPosition
+    impression: CellImpression
+}>
+
+export type BrailleDocument = Readonly<{
+    impressions: readonly PositionedCellImpression[]
+}>
+
+export type DocumentResult =
+    | Readonly<{
+          status: 'recorded'
+          document: BrailleDocument
+      }>
+    | Readonly<{
+          status: 'rejected'
+          document: BrailleDocument
+          error: Readonly<{
+              type: 'position-already-used'
+              position: GridPosition
+          }>
+      }>
+
+const assertCoordinate = (name: string, value: number) => {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new RangeError(`Invalid grid ${name}: ${value}`)
+    }
+}
+
+export const createGridPosition = (
+    row: number,
+    column: number,
+): GridPosition => {
+    assertCoordinate('row', row)
+    assertCoordinate('column', column)
+    return Object.freeze({ row, column })
+}
+
+export const createBrailleDocument = (): BrailleDocument =>
+    Object.freeze({ impressions: Object.freeze([]) })
+
+const positionsAreEqual = (left: GridPosition, right: GridPosition) =>
+    left.row === right.row && left.column === right.column
+
+export const getCellImpression = (
+    document: BrailleDocument,
+    position: GridPosition,
+): CellImpression | undefined =>
+    document.impressions.find((entry) =>
+        positionsAreEqual(entry.position, position),
+    )?.impression
+
+export const recordCellImpression = (
+    document: BrailleDocument,
+    position: GridPosition,
+    impression: CellImpression,
+): DocumentResult => {
+    if (getCellImpression(document, position) !== undefined) {
+        return Object.freeze({
+            status: 'rejected',
+            document,
+            error: Object.freeze({
+                type: 'position-already-used',
+                position,
+            }),
+        })
+    }
+
+    const entry = Object.freeze({ position, impression })
+    return Object.freeze({
+        status: 'recorded',
+        document: Object.freeze({
+            impressions: Object.freeze([...document.impressions, entry]),
+        }),
+    })
+}

--- a/src/braille/document/document.ts
+++ b/src/braille/document/document.ts
@@ -10,18 +10,18 @@ export type PositionedCellImpression = Readonly<{
     impression: CellImpression
 }>
 
-export type BrailleDocument = Readonly<{
+export type BrailleGrid = Readonly<{
     impressions: readonly PositionedCellImpression[]
 }>
 
-export type DocumentResult =
+export type GridResult =
     | Readonly<{
           status: 'recorded'
-          document: BrailleDocument
+          grid: BrailleGrid
       }>
     | Readonly<{
           status: 'rejected'
-          document: BrailleDocument
+          grid: BrailleGrid
           error: Readonly<{
               type: 'position-already-used'
               position: GridPosition
@@ -43,29 +43,29 @@ export const createGridPosition = (
     return Object.freeze({ row, column })
 }
 
-export const createBrailleDocument = (): BrailleDocument =>
+export const createBrailleGrid = (): BrailleGrid =>
     Object.freeze({ impressions: Object.freeze([]) })
 
 const positionsAreEqual = (left: GridPosition, right: GridPosition) =>
     left.row === right.row && left.column === right.column
 
 export const getCellImpression = (
-    document: BrailleDocument,
+    grid: BrailleGrid,
     position: GridPosition,
 ): CellImpression | undefined =>
-    document.impressions.find((entry) =>
+    grid.impressions.find((entry) =>
         positionsAreEqual(entry.position, position),
     )?.impression
 
 export const recordCellImpression = (
-    document: BrailleDocument,
+    grid: BrailleGrid,
     position: GridPosition,
     impression: CellImpression,
-): DocumentResult => {
-    if (getCellImpression(document, position) !== undefined) {
+): GridResult => {
+    if (getCellImpression(grid, position) !== undefined) {
         return Object.freeze({
             status: 'rejected',
-            document,
+            grid,
             error: Object.freeze({
                 type: 'position-already-used',
                 position,
@@ -76,8 +76,8 @@ export const recordCellImpression = (
     const entry = Object.freeze({ position, impression })
     return Object.freeze({
         status: 'recorded',
-        document: Object.freeze({
-            impressions: Object.freeze([...document.impressions, entry]),
+        grid: Object.freeze({
+            impressions: Object.freeze([...grid.impressions, entry]),
         }),
     })
 }

--- a/src/braille/document/impression.ts
+++ b/src/braille/document/impression.ts
@@ -1,0 +1,27 @@
+import {
+    createBrailleCell,
+    type BrailleCell,
+    type BrailleDot,
+} from '../machine/values'
+
+export type CellImpression = Readonly<{
+    cell: BrailleCell
+    erasedDots: readonly BrailleDot[]
+}>
+
+export const createCellImpression = (
+    cell: BrailleCell = createBrailleCell(),
+    erasedDots: readonly BrailleDot[] = [],
+): CellImpression => {
+    const overlappingDot = erasedDots.find((dot) => cell.dots.includes(dot))
+    if (overlappingDot !== undefined) {
+        throw new RangeError(
+            `A Braille dot cannot be both raised and erased: ${overlappingDot}`,
+        )
+    }
+
+    return Object.freeze({
+        cell,
+        erasedDots: Object.freeze([...new Set(erasedDots)].sort()),
+    })
+}

--- a/src/braille/public.ts
+++ b/src/braille/public.ts
@@ -21,12 +21,12 @@ export {
     type CellImpression,
 } from './document/impression'
 export {
-    createBrailleDocument,
+    createBrailleGrid,
     createGridPosition,
     getCellImpression,
     recordCellImpression,
-    type BrailleDocument,
-    type DocumentResult,
+    type BrailleGrid,
     type GridPosition,
+    type GridResult,
     type PositionedCellImpression,
 } from './document/document'

--- a/src/braille/public.ts
+++ b/src/braille/public.ts
@@ -16,3 +16,17 @@ export {
     type MachineIntent,
     type MachineOperation,
 } from './machine/machine'
+export {
+    createCellImpression,
+    type CellImpression,
+} from './document/impression'
+export {
+    createBrailleDocument,
+    createGridPosition,
+    getCellImpression,
+    recordCellImpression,
+    type BrailleDocument,
+    type DocumentResult,
+    type GridPosition,
+    type PositionedCellImpression,
+} from './document/document'


### PR DESCRIPTION
## Resumo

- adiciona Impressões de cela imutáveis com pontos elevados e vestígios apagados distintos
- registra a produção confirmada do Motor em posições explícitas de uma Grade Braille esparsa
- distingue espaço explícito, posição nunca utilizada e impressão com apagamento
- expõe erros estruturados sem converter o conteúdo em texto
- reserva a composição completa do Documento Braille com papel e posições para a #39

## Validação

- npm ci
- npm run ci
- git diff --check
- revisão Standards: 0 achados
- revisão Spec: 0 achados

Closes #38