### PR TITLE
feat(braille): interpreta sequências com rastreabilidade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
 - Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
 - Documento Braille editável e revisável com configuração e reformatação de
   folha finita ou papel contínuo, preservando impressões e vestígios físicos.
+- Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
+  2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
 
 ### Changed
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,6 +12,8 @@ Esta área descreve a arquitetura alvo da modernização. Ela é a fonte canôni
 - [Baseline operacional](modernization-baseline.md): marcos recuperáveis, jornadas essenciais, inventário legado e estratégia de rollback.
 - [Corte do build Vite](vite-build-baseline.md): comandos canônicos, artifact,
   evidências da coexistência encerrada e rollback do corte de plataforma.
+- [Perfil português Braille de 2018](../braille/portuguese-braille-2018.md):
+  regras atualmente interpretadas, exemplos, diagnósticos e limites conhecidos.
 
 ## Documentação relacionada
 

--- a/docs/braille/portuguese-braille-2018.md
+++ b/docs/braille/portuguese-braille-2018.md
@@ -1,0 +1,154 @@
+# Perfil português Braille de 2018
+
+## Identificação e fonte
+
+O perfil técnico `portuguese-braille-2018` representa o recorte atualmente
+implementado da **Grafia Braille para a Língua Portuguesa**, 3ª edição, publicada
+pelo Ministério da Educação em 2018. A fonte normativa está versionada em
+[`docs/Grafia Braille para a Língua Portuguesa.pdf`](../Grafia%20Braille%20para%20a%20Língua%20Portuguesa.pdf).
+
+Este perfil é selecionado explicitamente:
+
+```ts
+const profile = createOrthographyProfile('portuguese-braille-2018')
+const interpretation = interpretBrailleDocument(document, profile)
+```
+
+O nome não significa que toda a publicação normativa já esteja implementada.
+Ele identifica a norma usada pelas regras disponíveis. Sinais ainda não
+cobertos permanecem `unrecognized`, em vez de receberem equivalências do código
+legado ou de outra grafia.
+
+## Notação deste documento
+
+Uma cela é escrita pela lista dos pontos elevados entre parênteses. Assim,
+`(1)` é a letra `a`, `(12)` é `b`, `(46)` é o indicador de maiúscula e `()` é
+uma Impressão de cela vazia, isto é, um espaço explícito.
+
+## Letras atualmente reconhecidas
+
+| Letras | Pontos |
+| --- | --- |
+| a, b, c, d, e | (1), (12), (14), (145), (15) |
+| f, g, h, i, j | (124), (1245), (125), (24), (245) |
+| k, l, m, n, o | (13), (123), (134), (1345), (135) |
+| p, q, r, s, t | (1234), (12345), (1235), (234), (2345) |
+| u, v, w, x, y, z | (136), (1236), (2456), (1346), (13456), (1356) |
+| ç, á, à, â, ã | (12346), (12356), (1246), (16), (345) |
+| é, ê, í, ó, ô, õ, ú | (123456), (126), (34), (346), (1456), (246), (23456) |
+
+As letras são minúsculas por padrão. O perfil não infere maiúsculas pela
+posição na frase.
+
+## Indicadores de maiúscula
+
+### Uma letra
+
+O indicador `(46)` seguido imediatamente por uma letra forma uma letra
+maiúscula.
+
+```text
+(46) (1)  → A
+```
+
+O resultado preserva dois segmentos: o indicador `capital-letter` e o símbolo
+`A`. A origem de `A` inclui as duas celas. Sem uma letra adjacente, o indicador
+fica `pending`.
+
+### Uma palavra
+
+Dois indicadores adjacentes `(46) (46)` aplicam caixa alta às letras seguintes,
+até o primeiro sinal que não seja uma letra reconhecida.
+
+```text
+(46) (46) (12) (14)  → BC
+```
+
+O par continua visível como indicador `capital-word`; cada letra resultante
+referencia o par e sua própria cela.
+
+O indicador de série de palavras em caixa alta `(25) (46) (46)` ainda não faz
+parte do recorte implementado.
+
+## Números
+
+O indicador `(3456)` transforma as letras `a` a `j` imediatamente seguintes nos
+algarismos `1` a `0`.
+
+| Algarismos | Pontos após o indicador |
+| --- | --- |
+| 1, 2, 3, 4, 5 | (1), (12), (14), (145), (15) |
+| 6, 7, 8, 9, 0 | (124), (1245), (125), (24), (245) |
+
+```text
+(3456) (12) (245)  → 20
+```
+
+O número é um único segmento textual cuja origem inclui o indicador e todos os
+algarismos. O indicador também permanece como segmento `number`. Sem algarismo
+adjacente, ele fica `pending`.
+
+### Separador decimal
+
+A cela `(2)` entre algarismos de uma sequência numérica produz vírgula decimal:
+
+```text
+(3456) (145) (2) (15)  → 4,5
+```
+
+Somente uma vírgula decimal é consumida por número.
+
+### Separador de classes
+
+A cela `(3)` na parte inteira separa classes de exatamente três algarismos:
+
+```text
+(3456) (1) (245) (3) (245) (245) (245)  → 10 000
+```
+
+O grupo inicial pode ter de um a três algarismos; cada grupo posterior precisa
+ter três. O separador não é aceito depois da vírgula decimal. Uma estrutura
+inválida encerra o número antes da cela `(3)`, que volta a ser observada como
+ambígua.
+
+## Espaço, pontuação e diagnósticos
+
+| Entrada | Resultado atual |
+| --- | --- |
+| () | espaço explícito (`" "`) |
+| (2) | vírgula, fora de um número |
+| (23) | ponto e vírgula |
+| (25) | dois-pontos |
+| (26) | ponto de interrogação |
+| (235) | ponto de exclamação |
+| (36) | hífen |
+| (3) | `ambiguous`, com as alternativas ponto e apóstrofo |
+| qualquer cela não coberta | `unrecognized` |
+
+A ambiguidade de `(3)` fora do contexto numérico é deliberada: a norma atribui
+à cela funções de ponto e apóstrofo, e o recorte atual não aplica análise
+linguística suficiente para escolher uma delas.
+
+## Limites atuais
+
+Ainda não estão implementados, entre outros:
+
+- série de palavras em caixa alta e regras completas para siglas;
+- números ordinais, frações, numeração romana e articulação entre letras e
+  números;
+- sinais de ênfase, translineação, transpaginação e notas de transcrição;
+- conjunto completo de pontuação, símbolos acessórios, matemáticos e grafias
+  especializadas;
+- desambiguação linguística de ponto e apóstrofo.
+
+Essas ausências são parte do resultado observável: o algoritmo não substitui um
+sinal desconhecido por caractere aproximado. Cada ampliação deve citar a seção
+normativa correspondente, acrescentar exemplos públicos e preservar a
+rastreabilidade das celas.
+
+## Relação com o algoritmo
+
+A ordem de decisões, a formação das linhas e as regras de rastreabilidade estão
+documentadas em
+[`src/braille/orthography/README.md`](../../src/braille/orthography/README.md).
+

--- a/src/braille/README.md
+++ b/src/braille/README.md
@@ -32,6 +32,10 @@ Consumidores e testes importam somente `braille/public.ts`. A interface oferece:
   revisar o documento preservando as distinções mecânicas;
 - `prepareBrailleDocumentReformat` e `confirmBrailleDocumentReformat` para
   confirmar uma nova configuração e repartir as linhas sem perder impressões.
+- `createOrthographyProfile` para selecionar explicitamente a Grafia Braille
+  para a Língua Portuguesa, 3ª edição (2018);
+- `interpretBrailleDocument` para derivar linhas e Segmentos de interpretação
+  rastreáveis sem alterar o Documento Braille.
 
 Exemplo:
 
@@ -99,6 +103,32 @@ Coordenadas inválidas e sobreposição entre ponto elevado e apagado produzem
 um `GridResult` (Resultado da Grade) com erro estruturado e preservam o estado
 anterior.
 
+## Grafia e interpretação
+
+A visão detalhada do algoritmo, seus fluxos e regras de extensão está em
+[`orthography/README.md`](orthography/README.md). O recorte normativo do perfil
+português atual está em
+[`docs/braille/portuguese-braille-2018.md`](../../docs/braille/portuguese-braille-2018.md).
+
+- `OrthographyProfile` identifica a grafia e a edição normativa; perfis
+  desconhecidos são rejeitados, sem inferência silenciosa por idioma.
+- `BrailleInterpretation` é uma projeção imutável do Documento Braille. Cada
+  linha contém segmentos cujas posições em `source` apontam para as Impressões
+  de cela de origem.
+- Segmentos com `role: 'indicator'` permanecem explícitos mesmo quando não
+  produzem texto isoladamente. O símbolo resultante referencia também as celas
+  do indicador que lhe deram contexto.
+- Os indicadores de letra maiúscula, palavra em caixa alta e número são
+  resolvidos como sequências adjacentes. Dentro de um número, as celas de
+  vírgula decimal e de separação de classes são interpretadas pelo contexto
+  numérico; uma posição nunca utilizada interrompe o sinal.
+- Um indicador sem o sinal esperado produz `pending`; um sinal com mais de uma
+  leitura disponível produz `ambiguous`; conteúdo ainda não coberto pelo perfil
+  produz `unrecognized`. Nenhum desses estados inventa um Símbolo textual.
+- As tabelas e o estado contextual ficam internos ao módulo. Consumidores
+  escolhem o perfil e recebem a interpretação estruturada, sem controlar suas
+  regras.
+
 ## Dependências e adapters
 
 O Motor usa somente TypeScript e não depende de outras capacidades do produto.
@@ -109,11 +139,11 @@ texto localizado quando houver comunicação com a pessoa usuária.
 
 ## Estratégia de testes
 
-Os exemplos e invariantes são exercitados em `machine.test.ts` e
-`document.test.ts` exclusivamente por `braille/public.ts`. Os testes observam
-resultados públicos e não acessam arquivos internos nem efeitos de plataforma.
-Código e descrições dos testes usam inglês; este documento permanece em
-português.
+Os exemplos e invariantes são exercitados em `machine.test.ts`,
+`document.test.ts` e `orthography.test.ts` exclusivamente por
+`braille/public.ts`. Os testes observam resultados públicos e não acessam
+arquivos internos nem efeitos de plataforma. Código e descrições dos testes usam
+inglês; este documento permanece em português.
 
 ## Referências
 
@@ -125,3 +155,4 @@ português.
 - `docs/adr/0013-ingles-nos-contratos-tecnicos.md`
 - `docs/architecture/modules.md`
 - `docs/architecture/runtime-flows.md`
+- `docs/Grafia Braille para a Língua Portuguesa.pdf`

--- a/src/braille/orthography.test.ts
+++ b/src/braille/orthography.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+    applyDocumentOperation,
+    createBrailleCell,
+    createBrailleDocument,
+    createBrailleGrid,
+    createCellImpression,
+    createGridPosition,
+    createOrthographyProfile,
+    createPaperConfiguration,
+    interpretBrailleDocument,
+    recordCellImpression,
+    type BrailleDocument,
+} from './public'
+
+const createDocument = (lines: readonly (readonly (readonly number[])[])[]) => {
+    let document = createBrailleDocument(
+        createPaperConfiguration({ type: 'continuous', columns: 20 }),
+    )
+
+    lines.forEach((cells, line) => {
+        if (line > 0) {
+            document = applyDocumentOperation(document, { type: 'line-feed' })
+            document = applyDocumentOperation(document, {
+                type: 'carriage-return',
+            })
+        }
+        cells.forEach((dots) => {
+            document = applyDocumentOperation(document, {
+                type: 'confirm-cell',
+                cell: createBrailleCell(dots),
+            })
+        })
+    })
+
+    return document
+}
+
+const source = (...columns: number[]) =>
+    columns.map((column) => ({ sheet: 0, row: 0, column }))
+
+describe('Braille orthography', () => {
+    test('interprets symbols with an explicit profile and source positions', () => {
+        const document = createDocument([[[1], [1, 2], [], [1, 4]]])
+        const profile = createOrthographyProfile('portuguese-braille-2018')
+
+        const interpretation = interpretBrailleDocument(document, profile)
+
+        expect(interpretation.profile).toBe(profile)
+        expect(interpretation.lines).toEqual([
+            {
+                segments: [
+                    {
+                        status: 'interpreted',
+                        role: 'symbol',
+                        text: 'a',
+                        source: source(0),
+                    },
+                    {
+                        status: 'interpreted',
+                        role: 'symbol',
+                        text: 'b',
+                        source: source(1),
+                    },
+                    {
+                        status: 'interpreted',
+                        role: 'symbol',
+                        text: ' ',
+                        source: source(2),
+                    },
+                    {
+                        status: 'interpreted',
+                        role: 'symbol',
+                        text: 'c',
+                        source: source(3),
+                    },
+                ],
+            },
+        ])
+    })
+
+    test('interprets capital and number indicators as contextual sequences', () => {
+        const document = createDocument([
+            [[4, 6], [1], [], [3, 4, 5, 6], [1], [1, 2], [2], [1, 5]],
+        ])
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines[0]?.segments).toEqual([
+            {
+                status: 'interpreted',
+                role: 'indicator',
+                meaning: 'capital-letter',
+                source: source(0),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: 'A',
+                source: source(0, 1),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: ' ',
+                source: source(2),
+            },
+            {
+                status: 'interpreted',
+                role: 'indicator',
+                meaning: 'number',
+                source: source(3),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: '12,5',
+                source: source(3, 4, 5, 6, 7),
+            },
+        ])
+    })
+
+    test('applies a two-cell capital indicator to a complete word', () => {
+        const document = createDocument([
+            [
+                [4, 6],
+                [4, 6],
+                [1, 2],
+                [1, 4],
+            ],
+        ])
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines[0]?.segments).toEqual([
+            {
+                status: 'interpreted',
+                role: 'indicator',
+                meaning: 'capital-word',
+                source: source(0, 1),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: 'B',
+                source: source(0, 1, 2),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: 'C',
+                source: source(0, 1, 3),
+            },
+        ])
+    })
+
+    test('does not compose a signal across a never-used grid position', () => {
+        const base = createBrailleDocument(
+            createPaperConfiguration({ type: 'continuous', columns: 4 }),
+        )
+        const indicator = recordCellImpression(
+            createBrailleGrid(),
+            createGridPosition(0, 0),
+            createCellImpression(createBrailleCell([4, 6])),
+        )
+        if (indicator.status !== 'recorded') {
+            throw new Error('Expected capital indicator recording')
+        }
+        const letter = recordCellImpression(
+            indicator.grid,
+            createGridPosition(0, 2),
+            createCellImpression(createBrailleCell([1])),
+        )
+        if (letter.status !== 'recorded') {
+            throw new Error('Expected separated letter recording')
+        }
+        const document: BrailleDocument = Object.freeze({
+            ...base,
+            grids: Object.freeze([letter.grid]),
+        })
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines[0]?.segments).toEqual([
+            {
+                status: 'pending',
+                role: 'indicator',
+                meaning: 'capital-letter',
+                source: source(0),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: 'a',
+                source: source(2),
+            },
+        ])
+    })
+
+    test('interprets dot three as a class separator inside a number', () => {
+        const document = createDocument([
+            [
+                [3, 4, 5, 6],
+                [1],
+                [2, 4, 5],
+                [3],
+                [2, 4, 5],
+                [2, 4, 5],
+                [2, 4, 5],
+            ],
+        ])
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines[0]?.segments).toEqual([
+            {
+                status: 'interpreted',
+                role: 'indicator',
+                meaning: 'number',
+                source: source(0),
+            },
+            {
+                status: 'interpreted',
+                role: 'symbol',
+                text: '10 000',
+                source: source(0, 1, 2, 3, 4, 5, 6),
+            },
+        ])
+    })
+
+    test('keeps invalid numeric class separators ambiguous', () => {
+        const document = createDocument([
+            [[3, 4, 5, 6], [1], [3], [1, 2]],
+            [[3, 4, 5, 6], [1], [2], [1, 2], [3], [1, 4]],
+        ])
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines.map(({ segments }) => segments)).toEqual([
+            [
+                {
+                    status: 'interpreted',
+                    role: 'indicator',
+                    meaning: 'number',
+                    source: source(0),
+                },
+                {
+                    status: 'interpreted',
+                    role: 'symbol',
+                    text: '1',
+                    source: source(0, 1),
+                },
+                {
+                    status: 'ambiguous',
+                    role: 'symbol',
+                    alternatives: ['.', "'"],
+                    source: source(2),
+                },
+                {
+                    status: 'interpreted',
+                    role: 'symbol',
+                    text: 'b',
+                    source: source(3),
+                },
+            ],
+            [
+                {
+                    status: 'interpreted',
+                    role: 'indicator',
+                    meaning: 'number',
+                    source: [{ sheet: 0, row: 1, column: 0 }],
+                },
+                {
+                    status: 'interpreted',
+                    role: 'symbol',
+                    text: '1,2',
+                    source: [
+                        { sheet: 0, row: 1, column: 0 },
+                        { sheet: 0, row: 1, column: 1 },
+                        { sheet: 0, row: 1, column: 2 },
+                        { sheet: 0, row: 1, column: 3 },
+                    ],
+                },
+                {
+                    status: 'ambiguous',
+                    role: 'symbol',
+                    alternatives: ['.', "'"],
+                    source: [{ sheet: 0, row: 1, column: 4 }],
+                },
+                {
+                    status: 'interpreted',
+                    role: 'symbol',
+                    text: 'c',
+                    source: [{ sheet: 0, row: 1, column: 5 }],
+                },
+            ],
+        ])
+    })
+
+    test('keeps pending, ambiguous and unrecognized segments observable', () => {
+        const document = createDocument([[[3]], [[4]], [[4, 6]]])
+        const before = JSON.stringify(document)
+
+        const interpretation = interpretBrailleDocument(
+            document,
+            createOrthographyProfile('portuguese-braille-2018'),
+        )
+
+        expect(interpretation.lines).toEqual([
+            {
+                segments: [
+                    {
+                        status: 'ambiguous',
+                        role: 'symbol',
+                        alternatives: ['.', "'"],
+                        source: [{ sheet: 0, row: 0, column: 0 }],
+                    },
+                ],
+            },
+            {
+                segments: [
+                    {
+                        status: 'unrecognized',
+                        source: [{ sheet: 0, row: 1, column: 0 }],
+                    },
+                ],
+            },
+            {
+                segments: [
+                    {
+                        status: 'pending',
+                        role: 'indicator',
+                        meaning: 'capital-letter',
+                        source: [{ sheet: 0, row: 2, column: 0 }],
+                    },
+                ],
+            },
+        ])
+        expect(JSON.stringify(document)).toBe(before)
+    })
+
+    test('rejects an unknown orthography profile', () => {
+        expect(() =>
+            createOrthographyProfile('portuguese-braille-2025' as never),
+        ).toThrowError('Unknown Braille orthography profile')
+    })
+})

--- a/src/braille/orthography/README.md
+++ b/src/braille/orthography/README.md
@@ -1,0 +1,129 @@
+# Algoritmo de interpretação Braille
+
+Este documento explica como `interpretBrailleDocument` deriva uma
+`BrailleInterpretation` (Interpretação Braille) sem modificar nem substituir o
+`BrailleDocument` (Documento Braille). A referência do perfil atualmente
+implementado está em
+[`docs/braille/portuguese-braille-2018.md`](../../../docs/braille/portuguese-braille-2018.md).
+
+## Contrato
+
+A entrada é um Documento Braille e um `OrthographyProfile` (Perfil de grafia)
+criado explicitamente por `createOrthographyProfile`. A saída é uma projeção
+imutável, dividida em linhas e Segmentos de interpretação.
+
+O documento continua sendo a fonte de verdade. A interpretação não grava texto
+nas Impressões de cela, não altera posições e não remove vestígios de Apagamento
+físico. Reinterpretar o mesmo documento com o mesmo perfil produz o mesmo
+resultado.
+
+```mermaid
+flowchart LR
+    D[Documento Braille] --> L[Ordenar impressões por folha, linha e coluna]
+    P[Perfil de grafia explícito] --> I[Interpretar cada linha]
+    L --> I
+    I --> S[Construir segmentos rastreáveis]
+    S --> R[Interpretação Braille imutável]
+    D -. permanece inalterado .-> D
+```
+
+## Etapas
+
+### 1. Formar as sequências de cada linha
+
+O algoritmo percorre as Folhas Braille na ordem, agrupa as Impressões de cela
+por linha e ordena cada grupo pela coluna. Uma posição nunca utilizada não vira
+uma cela vazia: ela continua ausente e interrompe qualquer sinal que exija
+adjacência. Uma Impressão de cela sem pontos, por outro lado, é um espaço
+explícito e produz um segmento com `text: " "`.
+
+### 2. Reconhecer sinais contextuais
+
+Cada linha é analisada da esquerda para a direita. Antes da consulta aos sinais
+simples, o algoritmo procura indicadores conhecidos. Isso é importante porque a
+mesma Cela Braille pode mudar de significado conforme a sequência.
+
+```mermaid
+flowchart TD
+    A[Próxima Impressão de cela] --> B{Indicador de maiúscula?}
+    B -- sim --> C{Há outro indicador adjacente?}
+    C -- sim --> D{Há letra adjacente ao par?}
+    D -- sim --> DA[Consumir palavra adjacente em caixa alta]
+    D -- não --> G
+    C -- não --> E{Há letra adjacente?}
+    E -- sim --> F[Interpretar letra maiúscula]
+    E -- não --> G[Segmento pending]
+    B -- não --> H{Indicador de número?}
+    H -- sim --> I{Há sequência numérica válida e adjacente?}
+    I -- sim --> J[Consumir número e separadores válidos]
+    I -- não --> G
+    H -- não --> K{Espaço explícito?}
+    K -- sim --> L[Segmento interpreted: espaço]
+    K -- não --> M{Cela 3 fora de número?}
+    M -- sim --> N[Segmento ambiguous: ponto ou apóstrofo]
+    M -- não --> O{Sinal simples conhecido?}
+    O -- sim --> P[Segmento interpreted]
+    O -- não --> Q[Segmento unrecognized]
+    DA --> R[Continuar na próxima cela não consumida]
+    F --> R
+    G --> R
+    J --> R
+    L --> R
+    N --> R
+    P --> R
+    Q --> R
+```
+
+Os reconhecedores consomem somente celas adjacentes na mesma folha e linha. Por
+exemplo, o indicador de maiúscula na coluna 0 e a letra `a` na coluna 2 não
+formam `A` quando a coluna 1 nunca foi utilizada. O resultado contém um
+indicador `pending` e um `a` independente.
+
+### 3. Produzir segmentos e diagnósticos
+
+Há quatro estados observáveis:
+
+| Estado         | Significado                                                                    |
+| -------------- | ------------------------------------------------------------------------------ |
+| `interpreted`  | O perfil reconheceu o sinal e, quando aplicável, produziu `text` ou `meaning`. |
+| `pending`      | Um indicador conhecido ainda não possui a sequência necessária.                |
+| `ambiguous`    | O perfil conhece mais de uma leitura possível e não escolhe silenciosamente.   |
+| `unrecognized` | O perfil atual ainda não reconhece a cela ou sequência.                        |
+
+Indicadores reconhecidos permanecem como segmentos com `role: "indicator"`,
+mesmo sem texto próprio. O símbolo afetado forma outro segmento com
+`role: "symbol"`.
+
+### 4. Manter a rastreabilidade
+
+Todo segmento possui `source`, uma lista de `DocumentPosition` com folha, linha
+e coluna. Um símbolo contextual inclui tanto suas próprias celas quanto os
+indicadores que determinaram o significado. Por isso as origens podem se
+sobrepor entre segmentos.
+
+Exemplo para o número `12`, produzido pelas celas `(3456) (1) (12)`:
+
+```text
+indicator number  source: [coluna 0]
+symbol "12"       source: [colunas 0, 1, 2]
+```
+
+Essa sobreposição permite explicar tanto a função isolada do indicador quanto a
+origem completa do texto resultante.
+
+## Pureza e extensão
+
+As tabelas, a ordem de precedência e o estado transitório do reconhecimento são
+detalhes internos de `orthography.ts`. Consumidores selecionam um perfil
+conhecido e recebem segmentos; não injetam regras nem controlam o estado do
+parser.
+
+Ao ampliar um perfil:
+
+1. acrescente primeiro um exemplo normativo em `orthography.test.ts` pela
+   interface `braille/public.ts`;
+2. mantenha sinais compostos antes de sinais simples que compartilhem celas;
+3. exija adjacência quando a grafia definir uma sequência contínua;
+4. preserve `pending`, `ambiguous` ou `unrecognized` quando não houver base para
+   uma escolha única;
+5. atualize a referência específica do perfil e execute `npm run ci`.

--- a/src/braille/orthography/orthography.ts
+++ b/src/braille/orthography/orthography.ts
@@ -1,0 +1,438 @@
+import type {
+    BrailleDocument,
+    DocumentPosition,
+    PositionedCellImpression,
+} from '../document/document'
+
+export type OrthographyProfileId = 'portuguese-braille-2018'
+
+export type OrthographyProfile = Readonly<{
+    id: OrthographyProfileId
+    language: 'pt-BR'
+    edition: '2018'
+}>
+
+type InterpretationSource = readonly DocumentPosition[]
+
+export type InterpretedIndicatorSegment = Readonly<{
+    status: 'interpreted'
+    role: 'indicator'
+    source: InterpretationSource
+    meaning: 'capital-letter' | 'capital-word' | 'number'
+}>
+
+export type InterpretedSymbolSegment = Readonly<{
+    status: 'interpreted'
+    role: 'symbol'
+    source: InterpretationSource
+    text: string
+}>
+
+export type InterpretedSegment =
+    InterpretedIndicatorSegment | InterpretedSymbolSegment
+
+export type PendingSegment = Readonly<{
+    status: 'pending'
+    role: 'indicator'
+    meaning: 'capital-letter' | 'capital-word' | 'number'
+    source: InterpretationSource
+}>
+
+export type AmbiguousSegment = Readonly<{
+    status: 'ambiguous'
+    role: 'symbol'
+    alternatives: readonly string[]
+    source: InterpretationSource
+}>
+
+export type UnrecognizedSegment = Readonly<{
+    status: 'unrecognized'
+    source: InterpretationSource
+}>
+
+export type InterpretationSegment =
+    InterpretedSegment | PendingSegment | AmbiguousSegment | UnrecognizedSegment
+
+export type InterpretationLine = Readonly<{
+    segments: readonly InterpretationSegment[]
+}>
+
+export type BrailleInterpretation = Readonly<{
+    profile: OrthographyProfile
+    lines: readonly InterpretationLine[]
+}>
+
+type SourceImpression = Readonly<{
+    position: DocumentPosition
+    impression: PositionedCellImpression['impression']
+}>
+
+const letters = new Map<string, string>([
+    ['1', 'a'],
+    ['12', 'b'],
+    ['14', 'c'],
+    ['145', 'd'],
+    ['15', 'e'],
+    ['124', 'f'],
+    ['1245', 'g'],
+    ['125', 'h'],
+    ['24', 'i'],
+    ['245', 'j'],
+    ['13', 'k'],
+    ['123', 'l'],
+    ['134', 'm'],
+    ['1345', 'n'],
+    ['135', 'o'],
+    ['1234', 'p'],
+    ['12345', 'q'],
+    ['1235', 'r'],
+    ['234', 's'],
+    ['2345', 't'],
+    ['136', 'u'],
+    ['1236', 'v'],
+    ['2456', 'w'],
+    ['1346', 'x'],
+    ['13456', 'y'],
+    ['1356', 'z'],
+    ['12346', 'ç'],
+    ['123456', 'é'],
+    ['12356', 'á'],
+    ['23456', 'ú'],
+    ['16', 'â'],
+    ['126', 'ê'],
+    ['1456', 'ô'],
+    ['1246', 'à'],
+    ['246', 'õ'],
+    ['34', 'í'],
+    ['345', 'ã'],
+    ['346', 'ó'],
+])
+
+const symbols = new Map<string, string>([
+    ['2', ','],
+    ['23', ';'],
+    ['25', ':'],
+    ['26', '?'],
+    ['235', '!'],
+    ['36', '-'],
+])
+
+const digits = new Map<string, string>([
+    ['1', '1'],
+    ['12', '2'],
+    ['14', '3'],
+    ['145', '4'],
+    ['15', '5'],
+    ['124', '6'],
+    ['1245', '7'],
+    ['125', '8'],
+    ['24', '9'],
+    ['245', '0'],
+])
+
+const cellKey = (entry: SourceImpression) => entry.impression.cell.dots.join('')
+
+const areAdjacent = (left: SourceImpression, right: SourceImpression) =>
+    left.position.sheet === right.position.sheet &&
+    left.position.row === right.position.row &&
+    left.position.column + 1 === right.position.column
+
+const startsCompleteNumericClass = (
+    entries: readonly SourceImpression[],
+    separatorIndex: number,
+) => {
+    let previous = entries[separatorIndex]
+    if (previous === undefined) return false
+
+    for (let offset = 1; offset <= 3; offset += 1) {
+        const digit = entries[separatorIndex + offset]
+        if (
+            digit === undefined ||
+            !areAdjacent(previous, digit) ||
+            !digits.has(cellKey(digit))
+        ) {
+            return false
+        }
+        previous = digit
+    }
+
+    const following = entries[separatorIndex + 4]
+    return (
+        following === undefined ||
+        !areAdjacent(previous, following) ||
+        !digits.has(cellKey(following))
+    )
+}
+
+const freezeSource = (
+    entries: readonly SourceImpression[],
+): InterpretationSource => Object.freeze(entries.map((entry) => entry.position))
+
+const interpretedIndicator = (
+    meaning: InterpretedIndicatorSegment['meaning'],
+    entries: readonly SourceImpression[],
+): InterpretedIndicatorSegment =>
+    Object.freeze({
+        status: 'interpreted',
+        role: 'indicator',
+        meaning,
+        source: freezeSource(entries),
+    })
+
+const interpretedSymbol = (
+    text: string,
+    entries: readonly SourceImpression[],
+): InterpretedSymbolSegment =>
+    Object.freeze({
+        status: 'interpreted',
+        role: 'symbol',
+        text,
+        source: freezeSource(entries),
+    })
+
+const pendingIndicator = (
+    meaning: PendingSegment['meaning'],
+    entries: readonly SourceImpression[],
+): PendingSegment =>
+    Object.freeze({
+        status: 'pending',
+        role: 'indicator',
+        meaning,
+        source: freezeSource(entries),
+    })
+
+const sourceLines = (document: BrailleDocument): SourceImpression[][] => {
+    const lines: SourceImpression[][] = []
+    document.grids.forEach((grid, sheet) => {
+        const grouped = new Map<number, PositionedCellImpression[]>()
+        grid.impressions.forEach((entry) => {
+            const line = grouped.get(entry.position.row) ?? []
+            line.push(entry)
+            grouped.set(entry.position.row, line)
+        })
+        const orderedLines = [...grouped.entries()]
+        orderedLines
+            .sort(([left], [right]) => left - right)
+            .forEach(([row, entries]) => {
+                lines.push(
+                    entries
+                        .sort(
+                            (left, right) =>
+                                left.position.column - right.position.column,
+                        )
+                        .map((entry) =>
+                            Object.freeze({
+                                position: Object.freeze({
+                                    sheet,
+                                    row,
+                                    column: entry.position.column,
+                                }),
+                                impression: entry.impression,
+                            }),
+                        ),
+                )
+            })
+    })
+    return lines
+}
+
+const interpretLine = (
+    entries: readonly SourceImpression[],
+): InterpretationLine => {
+    const segments: InterpretationSegment[] = []
+    let index = 0
+
+    while (index < entries.length) {
+        const current = entries[index]
+        if (current === undefined) break
+        const key = cellKey(current)
+
+        if (key === '46') {
+            const next = entries[index + 1]
+            if (
+                next !== undefined &&
+                areAdjacent(current, next) &&
+                cellKey(next) === '46'
+            ) {
+                const wordEntries: SourceImpression[] = []
+                let cursor = index + 2
+                while (cursor < entries.length) {
+                    const entry = entries[cursor]
+                    const previous = entries[cursor - 1]
+                    if (
+                        entry === undefined ||
+                        previous === undefined ||
+                        !areAdjacent(previous, entry) ||
+                        !letters.has(cellKey(entry))
+                    ) {
+                        break
+                    }
+                    wordEntries.push(entry)
+                    cursor += 1
+                }
+                if (wordEntries.length === 0) {
+                    segments.push(
+                        pendingIndicator('capital-word', [current, next]),
+                    )
+                    index += 2
+                    continue
+                }
+                segments.push(
+                    interpretedIndicator('capital-word', [current, next]),
+                )
+                wordEntries.forEach((entry) => {
+                    const letter = letters.get(cellKey(entry))
+                    if (letter !== undefined) {
+                        segments.push(
+                            interpretedSymbol(letter.toUpperCase(), [
+                                current,
+                                next,
+                                entry,
+                            ]),
+                        )
+                    }
+                })
+                index = cursor
+                continue
+            }
+            const letter =
+                next === undefined || !areAdjacent(current, next)
+                    ? undefined
+                    : letters.get(cellKey(next))
+            if (letter === undefined) {
+                segments.push(pendingIndicator('capital-letter', [current]))
+                index += 1
+                continue
+            }
+            segments.push(interpretedIndicator('capital-letter', [current]))
+            segments.push(
+                interpretedSymbol(letter.toUpperCase(), [current, next]),
+            )
+            index += 2
+            continue
+        }
+
+        if (key === '3456') {
+            const numberEntries: SourceImpression[] = []
+            let numberText = ''
+            let hasDecimalSeparator = false
+            let hasClassSeparator = false
+            let digitsInCurrentClass = 0
+            let cursor = index + 1
+            while (cursor < entries.length) {
+                const entry = entries[cursor]
+                const previous = entries[cursor - 1]
+                if (
+                    entry === undefined ||
+                    previous === undefined ||
+                    !areAdjacent(previous, entry)
+                ) {
+                    break
+                }
+                const digit = digits.get(cellKey(entry))
+                if (digit !== undefined) {
+                    numberEntries.push(entry)
+                    numberText += digit
+                    digitsInCurrentClass += 1
+                    cursor += 1
+                    continue
+                }
+                const following = entries[cursor + 1]
+                if (
+                    cellKey(entry) === '2' &&
+                    numberText.length > 0 &&
+                    !hasDecimalSeparator &&
+                    (!hasClassSeparator || digitsInCurrentClass === 3) &&
+                    following !== undefined &&
+                    areAdjacent(entry, following) &&
+                    digits.has(cellKey(following))
+                ) {
+                    numberEntries.push(entry)
+                    numberText += ','
+                    hasDecimalSeparator = true
+                    cursor += 1
+                    continue
+                }
+                if (
+                    cellKey(entry) === '3' &&
+                    numberText.length > 0 &&
+                    !hasDecimalSeparator &&
+                    digitsInCurrentClass <= 3 &&
+                    startsCompleteNumericClass(entries, cursor) &&
+                    following !== undefined &&
+                    areAdjacent(entry, following) &&
+                    digits.has(cellKey(following))
+                ) {
+                    numberEntries.push(entry)
+                    numberText += ' '
+                    hasClassSeparator = true
+                    digitsInCurrentClass = 0
+                    cursor += 1
+                    continue
+                }
+                break
+            }
+            if (numberEntries.length === 0) {
+                segments.push(pendingIndicator('number', [current]))
+                index += 1
+                continue
+            }
+            segments.push(interpretedIndicator('number', [current]))
+            segments.push(
+                interpretedSymbol(numberText, [current, ...numberEntries]),
+            )
+            index = cursor
+            continue
+        }
+
+        if (key === '') {
+            segments.push(interpretedSymbol(' ', [current]))
+            index += 1
+            continue
+        }
+
+        if (key === '3') {
+            segments.push(
+                Object.freeze({
+                    status: 'ambiguous',
+                    role: 'symbol',
+                    alternatives: Object.freeze(['.', "'"]),
+                    source: freezeSource([current]),
+                }),
+            )
+            index += 1
+            continue
+        }
+
+        const text = letters.get(key) ?? symbols.get(key)
+        segments.push(
+            text === undefined
+                ? Object.freeze({
+                      status: 'unrecognized',
+                      source: freezeSource([current]),
+                  })
+                : interpretedSymbol(text, [current]),
+        )
+        index += 1
+    }
+
+    return Object.freeze({ segments: Object.freeze(segments) })
+}
+
+export const createOrthographyProfile = (
+    id: OrthographyProfileId,
+): OrthographyProfile => {
+    if (id !== 'portuguese-braille-2018') {
+        throw new RangeError(`Unknown Braille orthography profile: ${id}`)
+    }
+    return Object.freeze({ id, language: 'pt-BR', edition: '2018' })
+}
+
+export const interpretBrailleDocument = (
+    document: BrailleDocument,
+    profile: OrthographyProfile,
+): BrailleInterpretation =>
+    Object.freeze({
+        profile,
+        lines: Object.freeze(sourceLines(document).map(interpretLine)),
+    })

--- a/src/braille/public.ts
+++ b/src/braille/public.ts
@@ -46,3 +46,18 @@ export {
     type ReviewDirection,
     type SheetPaperConfiguration,
 } from './document/document'
+export {
+    createOrthographyProfile,
+    interpretBrailleDocument,
+    type AmbiguousSegment,
+    type BrailleInterpretation,
+    type InterpretationLine,
+    type InterpretationSegment,
+    type InterpretedIndicatorSegment,
+    type InterpretedSegment,
+    type InterpretedSymbolSegment,
+    type OrthographyProfile,
+    type OrthographyProfileId,
+    type PendingSegment,
+    type UnrecognizedSegment,
+} from './orthography/orthography'


### PR DESCRIPTION
## Resumo

- adiciona o perfil explícito da Grafia Braille para a Língua Portuguesa de 2018
- deriva segmentos imutáveis e rastreáveis sem alterar o Documento Braille
- interpreta indicadores de maiúscula, caixa alta, números e separadores por contexto e adjacência
- preserva estados pendente, ambíguo e não reconhecido
- documenta o algoritmo com fluxogramas e mantém uma referência específica do perfil português suportado

## Validação

- npm run ci
- 58 testes aprovados
- revisões de padrões e especificação sem findings

Closes #40