### PR TITLE
docs(changelog): adota padrão Keep a Changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ O repositório usa documentação de domínio single-context, escrita em portugu
 
 Código, testes e automações técnicas são escritos em inglês; documentação e comunicação dirigida a pessoas são escritas em português. Consulte `docs/agents/code-language.md`.
 
+### Changelog
+
+Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, comece cada item com a
+data `DD/MM/YYYY` em que a mudança entrou no histórico, seguida de `—` e
+da descrição em português. Confirme a data no histórico do Git (`git blame` ou
+`git log`) quando registrar mudanças existentes e preserve as categorias
+`Added`, `Changed`, `Fixed` e demais categorias já usadas no arquivo.
+
 ## Commits
 
 Quando houver autorização para criar um commit, use Conventional Commits no formato `tipo(escopo): descrição`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ Código, testes e automações técnicas são escritos em inglês; documentaçã
 ### Changelog
 
 Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, comece cada item com a
-data `DD/MM/YYYY` em que a mudança entrou no histórico, seguida de `—` e
-da descrição em português. Confirme a data no histórico do Git (`git blame` ou
+data `YYYY-MM-DD` em que a mudança entrou no histórico, seguida de `—` e da
+descrição em português. Ordene as entradas de cada categoria da mais recente
+para a mais antiga. Confirme a data no histórico do Git (`git blame` ou
 `git log`) quando registrar mudanças existentes e preserve as categorias
 `Added`, `Changed`, `Fixed` e demais categorias já usadas no arquivo.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,13 @@ Código, testes e automações técnicas são escritos em inglês; documentaçã
 Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, mantenha as mudanças
 ainda não publicadas sob `## [Unreleased]`, agrupe-as nas categorias `Added`,
 `Changed`, `Deprecated`, `Removed`, `Fixed` e `Security` quando aplicável e
-ordene as versões publicadas da mais recente para a mais antiga. Ao publicar
-uma versão, mova as entradas de `Unreleased` para um cabeçalho no formato
-`## [versão] - YYYY-MM-DD`, usando a data real do release. Preserve as
-categorias e o formato recomendados pelo Keep a Changelog.
+adicione cada nova entrada ao final da categoria correspondente, preservando a
+ordem em que as mudanças foram registradas. Não reordene a lista de
+`Unreleased` por data, commit ou prioridade. Ao publicar uma versão, mova todo
+o conteúdo de `Unreleased` para um cabeçalho no formato `## [versão] -
+YYYY-MM-DD`, usando a data real do release; coloque esse novo cabeçalho acima
+das versões já publicadas. Preserve as categorias e o formato recomendados pelo
+Keep a Changelog.
 
 ## Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,13 @@ Código, testes e automações técnicas são escritos em inglês; documentaçã
 
 ### Changelog
 
-Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, comece cada item com a
-data `YYYY-MM-DD` em que a mudança entrou no histórico, seguida de `—` e da
-descrição em português. Ordene as entradas de cada categoria da mais recente
-para a mais antiga. Confirme a data no histórico do Git (`git blame` ou
-`git log`) quando registrar mudanças existentes e preserve as categorias
-`Added`, `Changed`, `Fixed` e demais categorias já usadas no arquivo.
+Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, mantenha as mudanças
+ainda não publicadas sob `## [Unreleased]`, agrupe-as nas categorias `Added`,
+`Changed`, `Deprecated`, `Removed`, `Fixed` e `Security` quando aplicável e
+ordene as versões publicadas da mais recente para a mais antiga. Ao publicar
+uma versão, mova as entradas de `Unreleased` para um cabeçalho no formato
+`## [versão] - YYYY-MM-DD`, usando a data real do release. Preserve as
+categorias e o formato recomendados pelo Keep a Changelog.
 
 ## Commits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
 
 ### Added
 
-- Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
-  2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
+- Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
+- Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
+- Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
+- Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
+- Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
+- Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
 - Documento Braille editável e revisável com configuração e reformatação de
   folha finita ou papel contínuo, preservando impressões e vestígios físicos.
-- Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
-- Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
-- Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
-- Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
-- Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
-- Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
+- Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
+  2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Changelog
 
-Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias de Keep a Changelog; as versões seguem Semantic Versioning. Cada entrada começa com a data `DD/MM/YYYY` em que a mudança foi adicionada ao histórico.
+Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias de Keep a Changelog; as versões seguem Semantic Versioning. Cada entrada começa com a data `YYYY-MM-DD` em que a mudança foi adicionada ao histórico.
 
 ## [Unreleased]
 
 ### Added
 
-- 04/09/2026 — Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
-- 04/09/2026 — Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
-- 05/09/2026 — Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
-- 05/09/2026 — Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
-- 05/09/2026 — Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
-- 05/09/2026 — Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
-- 08/09/2026 — Documento Braille editável e revisável com configuração e reformatação de
-  folha finita ou papel contínuo, preservando impressões e vestígios físicos.
-- 09/09/2026 — Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
+- 2026-09-09 — Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
   2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
+- 2026-09-08 — Documento Braille editável e revisável com configuração e reformatação de
+  folha finita ou papel contínuo, preservando impressões e vestígios físicos.
+- 2026-09-05 — Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
+- 2026-09-05 — Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
+- 2026-09-05 — Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
+- 2026-09-05 — Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
+- 2026-09-04 — Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
+- 2026-09-04 — Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
 
 ### Changed
 
-- 08/09/2026 — TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
+- 2026-09-08 — TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
   política para supressões justificadas e locais.
-- 08/09/2026 — React e React DOM chegam à baseline 19.2.8 após a versão de transição,
+- 2026-09-08 — React e React DOM chegam à baseline 19.2.8 após a versão de transição,
   com adapters de teste e ícones compatíveis e inicialização por `createRoot`.
-- 07/09/2026 — Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
+- 2026-09-07 — Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
   caminho concorrente do Create React App foi removido.
 
 [Unreleased]: https://github.com/DavidGomesh/den-braille-typewriter/compare/v1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Changelog
 
-Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias de Keep a Changelog; as versões seguem Semantic Versioning.
+Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias de Keep a Changelog; as versões seguem Semantic Versioning. Cada entrada começa com a data `DD/MM/YYYY` em que a mudança foi adicionada ao histórico.
 
 ## [Unreleased]
 
 ### Added
 
-- Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
-- Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
-- Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
-- Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
-- Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
-- Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
-- Documento Braille editável e revisável com configuração e reformatação de
+- 04/09/2026 — Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
+- 04/09/2026 — Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
+- 05/09/2026 — Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
+- 05/09/2026 — Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
+- 05/09/2026 — Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
+- 05/09/2026 — Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
+- 08/09/2026 — Documento Braille editável e revisável com configuração e reformatação de
   folha finita ou papel contínuo, preservando impressões e vestígios físicos.
-- Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
+- 09/09/2026 — Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
   2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
 
 ### Changed
 
-- TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
+- 08/09/2026 — TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
   política para supressões justificadas e locais.
-- React e React DOM chegam à baseline 19.2.8 após a versão de transição,
+- 08/09/2026 — React e React DOM chegam à baseline 19.2.8 após a versão de transição,
   com adapters de teste e ícones compatíveis e inicialização por `createRoot`.
-- Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
+- 07/09/2026 — Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
   caminho concorrente do Create React App foi removido.
 
 [Unreleased]: https://github.com/DavidGomesh/den-braille-typewriter/compare/v1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Changelog
 
-Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias de Keep a Changelog; as versões seguem Semantic Versioning. Cada entrada começa com a data `YYYY-MM-DD` em que a mudança foi adicionada ao histórico.
+Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As descrições são escritas em português e seguem as categorias do [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/); as versões seguem Semantic Versioning. As datas aparecem nos cabeçalhos das versões publicadas no formato `YYYY-MM-DD`.
 
 ## [Unreleased]
 
 ### Added
 
-- 2026-09-09 — Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
+- Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
   2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
-- 2026-09-08 — Documento Braille editável e revisável com configuração e reformatação de
+- Documento Braille editável e revisável com configuração e reformatação de
   folha finita ou papel contínuo, preservando impressões e vestígios físicos.
-- 2026-09-05 — Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
-- 2026-09-05 — Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
-- 2026-09-05 — Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
-- 2026-09-05 — Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
-- 2026-09-04 — Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
-- 2026-09-04 — Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
+- Desenvolvimento e build Vite equivalentes ao CRA, com artifact próprio e base de publicação do projeto.
+- Separação contínua entre falhas herdadas de lint e novas regressões, com auditoria por advisory e pacote.
+- Ambiente legado reproduzível no Node.js 24, com instalação pelo lockfile, CI e baseline verificável de vulnerabilidades.
+- Baseline operacional da versão anterior à modernização, com jornadas essenciais, inventário técnico e referências recuperáveis.
+- Plano incremental da modernização, incluindo pré-lançamentos, critérios de conclusão, auditorias e rollback.
+- Documentação da arquitetura alvo por capacidades, com diagramas, interfaces e estrutura de diretórios.
 
 ### Changed
 
-- 2026-09-08 — TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
+- TypeScript passa para 6.0.3 em modo estrito, com typecheck sem emissão e
   política para supressões justificadas e locais.
-- 2026-09-08 — React e React DOM chegam à baseline 19.2.8 após a versão de transição,
+- React e React DOM chegam à baseline 19.2.8 após a versão de transição,
   com adapters de teste e ícones compatíveis e inicialização por `createRoot`.
-- 2026-09-07 — Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
+- Vite passa a ser o único caminho de desenvolvimento, build e publicação; o
   caminho concorrente do Create React App foi removido.
 
 [Unreleased]: https://github.com/DavidGomesh/den-braille-typewriter/compare/v1.0...HEAD


### PR DESCRIPTION
## Resumo

- alinha o CHANGELOG ao padrão Keep a Changelog
- mantém Unreleased no topo e restaura a ordem original das entradas
- documenta no AGENTS.md como adicionar itens e publicar versões

## Validação

- formatação verificada
- diff sem erros

