### PR TITLE
docs(braille): documenta contratos públicos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@ O repositório usa documentação de domínio single-context, escrita em portugu
 
 Código, testes e automações técnicas são escritos em inglês; documentação e comunicação dirigida a pessoas são escritas em português. Consulte `docs/agents/code-language.md`.
 
+### Code documentation
+
+Ao criar ou revisar APIs públicas, invariantes ou lógica interna não evidente,
+consulte `docs/agents/code-documentation.md`.
+
 ### Changelog
 
 Ao adicionar ou alterar uma entrada em `CHANGELOG.md`, mantenha as mudanças

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
   folha finita ou papel contínuo, preservando impressões e vestígios físicos.
 - Interpretação contextual pela Grafia Braille para a Língua Portuguesa de
   2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
+- Convenção de documentação de código e TSDoc nos contratos públicos da
+  capacidade Braille, com fluxo completo entre motor, documento e interpretação.
 
 ### Changed
 

--- a/docs/agents/code-documentation.md
+++ b/docs/agents/code-documentation.md
@@ -1,0 +1,89 @@
+# Documentação de código
+
+Estas regras orientam a documentação local de contratos e lógica de código. A
+arquitetura vigente continua em `docs/architecture/`, as decisões duráveis em
+`docs/adr/`, o vocabulário em `CONTEXT.md` e o comportamento executável no código
+e nos testes.
+
+## Contratos públicos
+
+Avalie cada símbolo exposto pela interface pública de uma capacidade. Escreva
+TSDoc junto à declaração original quando houver informação relevante que o tipo
+e o identificador não expressem sozinhos. O arquivo que reexporta a declaração
+não duplica seu TSDoc.
+
+Registre, quando aplicável:
+
+- o propósito no domínio e os limites da responsabilidade;
+- garantias, invariantes e distinções semânticas;
+- imutabilidade relevante para o consumo;
+- erros que o consumidor precisa antecipar;
+- um exemplo curto quando a forma correta de uso não for evidente.
+
+Use inglês no TSDoc, nos comentários e nos exemplos de código. Use português nos
+READMEs e demais explicações dirigidas a pessoas.
+
+```ts
+/**
+ * Creates the canonical, immutable representation of a Braille cell.
+ *
+ * Duplicate dots are removed and the remaining dots are sorted.
+ *
+ * @throws RangeError
+ * Thrown when any position is not an integer from 1 through 6.
+ */
+export const createBrailleCell = (
+    dots: readonly number[] = [],
+): BrailleCell => {
+    // ...
+}
+```
+
+Quando nome e tipo já comunicarem todo o contrato, mantenha a declaração sem
+comentário. A revisão avalia a informação comunicada, não a presença mecânica de
+um bloco TSDoc.
+
+## Lógica interna
+
+Antes de comentar lógica interna difícil, melhore nomes e decomposição quando
+isso puder tornar o comportamento evidente sem uma refatoração estrutural.
+Comentários remanescentes explicam a razão, a regra normativa, a invariante ou
+a escolha algorítmica. Preserve mudanças estruturais maiores para uma tarefa
+própria.
+
+Prefira:
+
+```ts
+// A never-used position breaks adjacency even when the next cell is textual.
+```
+
+Evite narrar a instrução ou repetir o tipo:
+
+```ts
+// Increment the index.
+index += 1
+
+// Returns a Braille cell.
+const createBrailleCell = (): BrailleCell => {
+    // ...
+}
+```
+
+## Fluxos entre módulos
+
+Mantenha exemplos pequenos junto aos contratos. Quando o entendimento depender
+da colaboração entre módulos, documente um ou dois fluxos completos no README da
+capacidade, consumindo apenas sua interface pública. O exemplo deve revelar a
+ordem das operações e as fronteiras entre responsabilidades sem reproduzir a
+implementação interna.
+
+## Revisão
+
+Considere a documentação concluída quando:
+
+- todos os contratos públicos alterados foram avaliados segundo estas regras;
+- o consumidor encontra propósito, garantias, invariantes e erros relevantes
+  sem reconstruí-los a partir de detalhes internos;
+- os comentários explicam o porquê e continuam coerentes com código e testes;
+- os fluxos documentados usam somente a interface pública da capacidade;
+- formatação, lint, typecheck, testes e build continuam aprovados.

--- a/src/braille/README.md
+++ b/src/braille/README.md
@@ -37,7 +37,7 @@ Consumidores e testes importam somente `braille/public.ts`. A interface oferece:
 - `interpretBrailleDocument` para derivar linhas e Segmentos de interpretação
   rastreáveis sem alterar o Documento Braille.
 
-Exemplo:
+Exemplo mínimo do ciclo de um acorde:
 
 ```ts
 import { applyIntent, createBrailleDot, createEngineState } from './public'
@@ -52,6 +52,65 @@ const confirmed = applyIntent(pressed.state, {
     control: { type: 'dot', dot: createBrailleDot(1) },
 })
 ```
+
+## Fluxo entre motor, documento e interpretação
+
+O Motor converte intenções normalizadas em operações sem conhecer o documento.
+O Documento Braille aplica essas operações como sua fonte de verdade. A Grafia
+Braille deriva uma interpretação rastreável desse documento, sem substituí-lo.
+
+```ts
+import {
+    applyDocumentOperation,
+    applyIntent,
+    createBrailleDocument,
+    createBrailleDot,
+    createEngineState,
+    createOrthographyProfile,
+    createPaperConfiguration,
+    interpretBrailleDocument,
+    type BrailleDocument,
+    type EngineEvent,
+} from './public'
+
+const applyEngineEvents = (
+    document: BrailleDocument,
+    events: readonly EngineEvent[],
+) =>
+    events.reduce(
+        (current, event) =>
+            event.type === 'operation-produced'
+                ? applyDocumentOperation(current, event.operation)
+                : current,
+        document,
+    )
+
+const initialEngine = createEngineState()
+const pressed = applyIntent(initialEngine, {
+    type: 'press',
+    control: { type: 'dot', dot: createBrailleDot(1) },
+})
+const released = applyIntent(pressed.state, {
+    type: 'release',
+    control: { type: 'dot', dot: createBrailleDot(1) },
+})
+
+const initialDocument = createBrailleDocument(
+    createPaperConfiguration({ type: 'continuous', columns: 20 }),
+)
+const document = applyEngineEvents(initialDocument, released.events)
+const interpretation = interpretBrailleDocument(
+    document,
+    createOrthographyProfile('portuguese-braille-2018'),
+)
+
+// `document` preserves the Braille cell; `interpretation` projects it as "a".
+```
+
+Nesse fluxo, `input-rejected` e `chord-discarded` continuam disponíveis para
+Feedback multimodal, mas não são operações do documento. Essa distinção permite
+que a futura Sessão de digitação coordene as capacidades sem transferir regras
+de captura ou apresentação para `braille`.
 
 ## Invariantes e ordem
 

--- a/src/braille/document/document.ts
+++ b/src/braille/document/document.ts
@@ -3,20 +3,29 @@ import { createCellImpression } from './impression'
 import { createBrailleCell, type BrailleDot } from '../machine/values'
 import type { MachineOperation } from '../machine/machine'
 
+/** A zero-based, non-negative position within one Braille grid. */
 export type GridPosition = Readonly<{
     row: number
     column: number
 }>
 
+/** A used grid position paired with its recorded physical impression. */
 export type PositionedCellImpression = Readonly<{
     position: GridPosition
     impression: CellImpression
 }>
 
+/**
+ * A sparse, immutable collection of used positions.
+ *
+ * Positions absent from `impressions` have never been used; explicit spaces
+ * remain present as empty cell impressions.
+ */
 export type BrailleGrid = Readonly<{
     impressions: readonly PositionedCellImpression[]
 }>
 
+/** The observable result of attempting to occupy a grid position. */
 export type GridResult =
     | Readonly<{
           status: 'recorded'
@@ -37,6 +46,12 @@ const assertCoordinate = (name: string, value: number) => {
     }
 }
 
+/**
+ * Creates a validated position within a grid.
+ *
+ * @throws RangeError
+ * Thrown when either coordinate is negative or is not an integer.
+ */
 export const createGridPosition = (
     row: number,
     column: number,
@@ -46,12 +61,19 @@ export const createGridPosition = (
     return Object.freeze({ row, column })
 }
 
+/** Creates an empty immutable grid in which every position is never used. */
 export const createBrailleGrid = (): BrailleGrid =>
     Object.freeze({ impressions: Object.freeze([]) })
 
 const positionsAreEqual = (left: GridPosition, right: GridPosition) =>
     left.row === right.row && left.column === right.column
 
+/**
+ * Reads a used grid position without changing the grid.
+ *
+ * @returns The recorded impression, or `undefined` when the position has never
+ * been used.
+ */
 export const getCellImpression = (
     grid: BrailleGrid,
     position: GridPosition,
@@ -60,6 +82,12 @@ export const getCellImpression = (
         positionsAreEqual(entry.position, position),
     )?.impression
 
+/**
+ * Records an impression only when the position has never been used.
+ *
+ * A conflict is returned as `position-already-used`; it preserves the original
+ * grid and does not overwrite even an explicit space.
+ */
 export const recordCellImpression = (
     grid: BrailleGrid,
     position: GridPosition,
@@ -85,6 +113,7 @@ export const recordCellImpression = (
     })
 }
 
+/** Non-negative reserved rows and columns at each paper edge. */
 export type PaperMargins = Readonly<{
     top: number
     right: number
@@ -99,17 +128,20 @@ type PaperDetails = Readonly<{
     orientation?: 'portrait' | 'landscape'
 }>
 
+/** A finite paper configuration that may continue onto additional sheets. */
 export type SheetPaperConfiguration = PaperDetails &
     Readonly<{
         type: 'sheet'
         rows: number
     }>
 
+/** A single-grid paper configuration with unbounded rows. */
 export type ContinuousPaperConfiguration = PaperDetails &
     Readonly<{
         type: 'continuous'
     }>
 
+/** The validated geometry shared by every grid in a Braille document. */
 export type PaperConfiguration =
     SheetPaperConfiguration | ContinuousPaperConfiguration
 
@@ -128,12 +160,19 @@ type PaperConfigurationInput =
           margins?: Pick<Partial<PaperMargins>, 'left' | 'right'>
       }>
 
+/** A zero-based coordinate in the ordered grids of a Braille document. */
 export type DocumentPosition = Readonly<{
     sheet: number
     row: number
     column: number
 }>
 
+/**
+ * The immutable source of truth for Braille production and navigation.
+ *
+ * Editing and review positions evolve independently, and textual
+ * interpretation is deliberately excluded.
+ */
 export type BrailleDocument = Readonly<{
     paper: PaperConfiguration
     grids: readonly BrailleGrid[]
@@ -145,6 +184,12 @@ export type ReviewDirection = 'up' | 'right' | 'down' | 'left'
 
 const preparedReformat = Symbol('prepared Braille document reformat')
 
+/**
+ * An opaque, prepared reformat that must be confirmed explicitly.
+ *
+ * Consumers cannot construct this value without
+ * `prepareBrailleDocumentReformat`.
+ */
 export type BrailleDocumentReformat = Readonly<{
     [preparedReformat]: true
     document: BrailleDocument
@@ -167,6 +212,16 @@ const freezeMargins = (
         left: margins?.left ?? 0,
     })
 
+/**
+ * Validates and canonicalizes the geometry for finite or continuous paper.
+ *
+ * Missing margins default to zero. Continuous paper accepts only horizontal
+ * margins because its rows are unbounded.
+ *
+ * @throws RangeError
+ * Thrown for non-positive dimensions, invalid margins, or margins that leave no
+ * writable row or column.
+ */
 export const createPaperConfiguration = (
     input: PaperConfigurationInput,
 ): PaperConfiguration => {
@@ -227,6 +282,12 @@ const freezeDocument = (
         reviewPosition,
     })
 
+/**
+ * Creates an empty document positioned at the first writable cell.
+ *
+ * The editing and review positions initially coincide, and the first grid is
+ * present even though all its positions are never used.
+ */
 export const createBrailleDocument = (
     paper: PaperConfiguration,
 ): BrailleDocument => {
@@ -234,6 +295,16 @@ export const createBrailleDocument = (
     return freezeDocument(paper, [createBrailleGrid()], position, position)
 }
 
+/**
+ * Reads an impression by document coordinate without changing the document.
+ *
+ * @returns The recorded impression, or `undefined` for a missing grid or a
+ * never-used position.
+ *
+ * @throws RangeError
+ * Thrown when the row or column is negative or is not an integer in an existing
+ * grid.
+ */
 export const getDocumentCellImpression = (
     document: BrailleDocument,
     position: DocumentPosition,
@@ -369,6 +440,14 @@ const embossCell = (
     )
 }
 
+/**
+ * Applies a semantic machine operation as an immutable document transition.
+ *
+ * Confirming a cell raises its dots at the editing position and restores any
+ * matching erased traces before advancing. Space records an explicit empty
+ * impression. Backspace, line feed, and carriage return move the editing
+ * position according to their distinct mechanical meanings.
+ */
 export const applyDocumentOperation = (
     document: BrailleDocument,
     operation: MachineOperation,
@@ -416,6 +495,12 @@ export const applyDocumentOperation = (
     )
 }
 
+/**
+ * Physically erases selected raised dots while preserving their traces.
+ *
+ * Dots that are absent or already erased have no additional effect. A
+ * never-used position preserves the original document.
+ */
 export const eraseCellDots = (
     document: BrailleDocument,
     position: DocumentPosition,
@@ -441,6 +526,13 @@ export const eraseCellDots = (
     )
 }
 
+/**
+ * Moves only the review position within the currently reachable document.
+ *
+ * Horizontal movement stays inside writable columns. Vertical movement may
+ * cross existing finite sheets, but it never creates a sheet or changes the
+ * editing position or content.
+ */
 export const moveReviewPosition = (
     document: BrailleDocument,
     direction: ReviewDirection,
@@ -592,12 +684,25 @@ const reformatBrailleDocument = (
     return freezeDocument(paper, reformatted.grids, position, position)
 }
 
+/**
+ * Prepares an explicit paper change without modifying the source document.
+ *
+ * The opaque result records both the original document and validated target
+ * paper for later confirmation.
+ */
 export const prepareBrailleDocumentReformat = (
     document: BrailleDocument,
     paper: PaperConfiguration,
 ): BrailleDocumentReformat =>
     Object.freeze({ [preparedReformat]: true, document, paper })
 
+/**
+ * Confirms a prepared reformat and returns a new immutable document.
+ *
+ * Each old line is wrapped independently into the target writable area. Used
+ * impressions and internal empty lines are preserved; content from separate
+ * old lines is never recombined.
+ */
 export const confirmBrailleDocumentReformat = (
     reformat: BrailleDocumentReformat,
 ): BrailleDocument => {

--- a/src/braille/document/impression.ts
+++ b/src/braille/document/impression.ts
@@ -4,11 +4,25 @@ import {
     type BrailleDot,
 } from '../machine/values'
 
+/**
+ * The physical state recorded at one used grid position.
+ *
+ * Raised dots and erased traces are disjoint. A cell with neither still records
+ * an explicit space and is not equivalent to an absent grid position.
+ */
 export type CellImpression = Readonly<{
     cell: BrailleCell
     erasedDots: readonly BrailleDot[]
 }>
 
+/**
+ * Creates an immutable cell impression with canonical erased traces.
+ *
+ * Duplicate erased dots are removed and the remainder are sorted.
+ *
+ * @throws RangeError
+ * Thrown when a dot is both raised in `cell` and present in `erasedDots`.
+ */
 export const createCellImpression = (
     cell: BrailleCell = createBrailleCell(),
     erasedDots: readonly BrailleDot[] = [],

--- a/src/braille/machine/machine.ts
+++ b/src/braille/machine/machine.ts
@@ -1,8 +1,13 @@
 import { createBrailleCell, type BrailleCell, type BrailleDot } from './values'
 
+/** A non-dot machine control and the operation it produces when released. */
 export type DirectOperationType =
     'space' | 'backspace' | 'line-feed' | 'carriage-return'
 
+/**
+ * A logical machine control independent of its keyboard, touch, or other input
+ * adapter.
+ */
 export type MachineControl =
     | Readonly<{
           type: 'dot'
@@ -10,6 +15,12 @@ export type MachineControl =
       }>
     | Readonly<{ type: DirectOperationType }>
 
+/**
+ * A normalized request to change the machine input state.
+ *
+ * Cancellation always discards a chord. Capture interruption makes the choice
+ * between discarding and confirming explicit in its policy.
+ */
 export type MachineIntent =
     | Readonly<{ type: 'press'; control: MachineControl }>
     | Readonly<{ type: 'release'; control: MachineControl }>
@@ -19,6 +30,10 @@ export type MachineIntent =
           policy: 'discard' | 'confirm'
       }>
 
+/**
+ * A semantic machine result that can be applied by a typing session or Braille
+ * document without knowing the originating device.
+ */
 export type MachineOperation =
     | Readonly<{
           type: 'confirm-cell'
@@ -26,6 +41,12 @@ export type MachineOperation =
       }>
     | Readonly<{ type: DirectOperationType }>
 
+/**
+ * An observable semantic fact produced while applying a machine intent.
+ *
+ * Rejected input is represented as data instead of an exception so adapters
+ * can choose an appropriate feedback modality.
+ */
 export type EngineEvent =
     | Readonly<{
           type: 'operation-produced'
@@ -41,12 +62,19 @@ export type EngineEvent =
           cell: BrailleCell
       }>
 
+/**
+ * The immutable authoritative state carried between engine transitions.
+ *
+ * `accumulatedDots` retains every dot pressed in the current chord, while
+ * `pressedDots` contains only dots that have not yet been released.
+ */
 export type EngineState = Readonly<{
     accumulatedDots: readonly BrailleDot[]
     pressedDots: readonly BrailleDot[]
     pressedControls: readonly DirectOperationType[]
 }>
 
+/** A read-only projection of the engine state intended for consumers. */
 export type EngineSnapshot = Readonly<{
     chord: Readonly<{
         accumulatedDots: readonly BrailleDot[]
@@ -55,6 +83,7 @@ export type EngineSnapshot = Readonly<{
     pressedControls: readonly DirectOperationType[]
 }>
 
+/** The immutable outcome of one engine transition. */
 export type EngineResult = Readonly<{
     state: EngineState
     snapshot: EngineSnapshot
@@ -72,6 +101,7 @@ const createState = (
         pressedControls: Object.freeze([...pressedControls].sort()),
     })
 
+/** Creates an engine state with no chord or direct control in progress. */
 export const createEngineState = (): EngineState => createState([], [])
 
 const createResult = (
@@ -90,6 +120,25 @@ const createResult = (
         events: Object.freeze([...events]),
     })
 
+/**
+ * Applies one normalized intent as a pure engine transition.
+ *
+ * A chord is confirmed only after its last pressed dot is released. Invalid
+ * press-and-release sequences preserve the state and produce `input-rejected`.
+ * Cancellation and interruption never throw for the current engine state.
+ *
+ * @example
+ * ```ts
+ * const pressed = applyIntent(createEngineState(), {
+ *     type: 'press',
+ *     control: { type: 'dot', dot: createBrailleDot(1) },
+ * })
+ * const released = applyIntent(pressed.state, {
+ *     type: 'release',
+ *     control: { type: 'dot', dot: createBrailleDot(1) },
+ * })
+ * ```
+ */
 export const applyIntent = (
     state: EngineState,
     intent: MachineIntent,

--- a/src/braille/machine/values.ts
+++ b/src/braille/machine/values.ts
@@ -1,9 +1,17 @@
+/** One of the six numbered positions in a Braille cell. */
 export type BrailleDot = 1 | 2 | 3 | 4 | 5 | 6
 
+/** An immutable Braille cell with distinct dots in ascending order. */
 export type BrailleCell = Readonly<{
     dots: readonly BrailleDot[]
 }>
 
+/**
+ * Validates a numeric position as one of the six Braille dots.
+ *
+ * @throws RangeError
+ * Thrown when `position` is not an integer from 1 through 6.
+ */
 export const createBrailleDot = (position: number): BrailleDot => {
     if (!Number.isInteger(position) || position < 1 || position > 6) {
         throw new RangeError(`Invalid Braille dot position: ${position}`)
@@ -12,6 +20,15 @@ export const createBrailleDot = (position: number): BrailleDot => {
     return position as BrailleDot
 }
 
+/**
+ * Creates the canonical, immutable representation of a Braille cell.
+ *
+ * Duplicate dots are removed and the remaining dots are sorted. An empty cell
+ * is valid and remains distinct from a never-used document position.
+ *
+ * @throws RangeError
+ * Thrown when any position is not an integer from 1 through 6.
+ */
 export const createBrailleCell = (
     positions: readonly number[] = [],
 ): BrailleCell => {

--- a/src/braille/orthography/orthography.ts
+++ b/src/braille/orthography/orthography.ts
@@ -4,8 +4,10 @@ import type {
     PositionedCellImpression,
 } from '../document/document'
 
+/** The stable identity of every orthography profile supported by this build. */
 export type OrthographyProfileId = 'portuguese-braille-2018'
 
+/** An explicit language-and-edition identity for Braille interpretation. */
 export type OrthographyProfile = Readonly<{
     id: OrthographyProfileId
     language: 'pt-BR'
@@ -14,6 +16,7 @@ export type OrthographyProfile = Readonly<{
 
 type InterpretationSource = readonly DocumentPosition[]
 
+/** A recognized indicator that changes how following cells are interpreted. */
 export type InterpretedIndicatorSegment = Readonly<{
     status: 'interpreted'
     role: 'indicator'
@@ -21,6 +24,12 @@ export type InterpretedIndicatorSegment = Readonly<{
     meaning: 'capital-letter' | 'capital-word' | 'number'
 }>
 
+/**
+ * A recognized textual symbol with every contributing cell in `source`.
+ *
+ * Contextual symbols include their indicator positions as well as the cell
+ * that directly produces text.
+ */
 export type InterpretedSymbolSegment = Readonly<{
     status: 'interpreted'
     role: 'symbol'
@@ -28,9 +37,11 @@ export type InterpretedSymbolSegment = Readonly<{
     text: string
 }>
 
+/** A successfully recognized indicator or textual symbol. */
 export type InterpretedSegment =
     InterpretedIndicatorSegment | InterpretedSymbolSegment
 
+/** A recognized indicator that lacks the adjacent cells needed to resolve it. */
 export type PendingSegment = Readonly<{
     status: 'pending'
     role: 'indicator'
@@ -38,6 +49,7 @@ export type PendingSegment = Readonly<{
     source: InterpretationSource
 }>
 
+/** A source sequence for which the profile preserves multiple valid readings. */
 export type AmbiguousSegment = Readonly<{
     status: 'ambiguous'
     role: 'symbol'
@@ -45,18 +57,31 @@ export type AmbiguousSegment = Readonly<{
     source: InterpretationSource
 }>
 
+/** A source sequence not covered by the selected profile. */
 export type UnrecognizedSegment = Readonly<{
     status: 'unrecognized'
     source: InterpretationSource
 }>
 
+/**
+ * One traceable interpretation outcome.
+ *
+ * Pending, ambiguous, and unrecognized outcomes remain explicit so consumers
+ * never need to infer invented text.
+ */
 export type InterpretationSegment =
     InterpretedSegment | PendingSegment | AmbiguousSegment | UnrecognizedSegment
 
+/** Ordered interpretation segments derived from one used document line. */
 export type InterpretationLine = Readonly<{
     segments: readonly InterpretationSegment[]
 }>
 
+/**
+ * An immutable textual projection that retains its profile and source mapping.
+ *
+ * It is derived data and never replaces or modifies the Braille document.
+ */
 export type BrailleInterpretation = Readonly<{
     profile: OrthographyProfile
     lines: readonly InterpretationLine[]
@@ -419,6 +444,13 @@ const interpretLine = (
     return Object.freeze({ segments: Object.freeze(segments) })
 }
 
+/**
+ * Selects a supported Braille orthography by its normative identity.
+ *
+ * @throws Error
+ * Thrown when `id` does not name a supported profile. The function never falls
+ * back to a profile based only on language.
+ */
 export const createOrthographyProfile = (
     id: OrthographyProfileId,
 ): OrthographyProfile => {
@@ -428,6 +460,13 @@ export const createOrthographyProfile = (
     return Object.freeze({ id, language: 'pt-BR', edition: '2018' })
 }
 
+/**
+ * Interprets used document positions with the selected contextual profile.
+ *
+ * Never-used positions break adjacency, while explicit empty impressions
+ * produce spaces. Every outcome remains traceable through document positions,
+ * and the source document is not modified.
+ */
 export const interpretBrailleDocument = (
     document: BrailleDocument,
     profile: OrthographyProfile,


### PR DESCRIPTION
## Resumo

- estabelece uma convenção de TSDoc para contratos públicos e lógica não evidente;
- documenta os contratos expostos pela capacidade `braille` nas declarações originais;
- demonstra o fluxo completo entre Motor, Documento Braille e Interpretação Braille;
- registra a convenção nas instruções para agentes e no changelog.

## Validação

- `npm run ci`
- formatação, lint, typecheck e fronteiras arquiteturais aprovados;
- 58 testes Vitest e 30 testes de guardrails aprovados;
- build e auditoria aprovados dentro dos baselines existentes.

Closes #70.
