### PR TITLE
feat(session): conecta o Modo livre à nova sessão

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,10 @@ module.exports = {
             },
         },
         {
-            files: ['src/tests/**/*.{js,jsx,ts,tsx}'],
+            files: [
+                'src/tests/**/*.{js,jsx,ts,tsx}',
+                'tests/**/*.{js,jsx,ts,tsx}',
+            ],
             extends: ['plugin:testing-library/react'],
         },
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
   2018, com segmentos rastreáveis e estados pendente, ambíguo e não reconhecido.
 - Convenção de documentação de código e TSDoc nos contratos públicos da
   capacidade Braille, com fluxo completo entre motor, documento e interpretação.
+- Sessão de digitação pura e adapter web de teclado integrados ao Modo livre,
+  com captura focada e Documento Braille como única fonte de verdade.
 
 ### Changed
 

--- a/config/lint-baseline.json
+++ b/config/lint-baseline.json
@@ -11,9 +11,6 @@
     "failures": [
         "src/components/Typewriter.tsx:react-hooks/exhaustive-deps:React Hook useEffect has missing dependencies: 'isOutputMuted', 'noKeyPressedCurrently', 'outputReference', 'playCellAudio', 'pressedKeys', and 'typedCells'. Either include them or remove the dependency array. You can also do a functional update 'setPressedKeys(p => ...)' if you only need 'pressedKeys' in the 'setPressedKeys' call.",
         "src/tests/Journeys.test.tsx:testing-library/no-container:Avoid using container methods. Prefer using the methods from Testing Library, such as \"getByRole()\"",
-        "src/tests/Journeys.test.tsx:testing-library/no-container:Avoid using container methods. Prefer using the methods from Testing Library, such as \"getByRole()\"",
-        "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
-        "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
         "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
         "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
         "src/views/Home.tsx:@typescript-eslint/no-unused-vars:'handleBtnAboutFocused' is defined but never used.",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,6 +9,8 @@ Esta área descreve a arquitetura alvo da modernização. Ela é a fonte canôni
 - [Fluxos em execução](runtime-flows.md): sequências principais da entrada ao feedback e das Experiências do simulador.
 - [Estrutura de diretórios](directory-structure.md): árvore alvo e regras para localizar código e testes.
 - [Plano de migração](migration-plan.md): fases, pré-requisitos, versões, auditorias e rollback.
+- [Prontidão da Sessão para Alpha 1](session-alpha-1.md): portões, evidências e
+  rollback do corte do Modo livre.
 - [Baseline operacional](modernization-baseline.md): marcos recuperáveis, jornadas essenciais, inventário legado e estratégia de rollback.
 - [Corte do build Vite](vite-build-baseline.md): comandos canônicos, artifact,
   evidências da coexistência encerrada e rollback do corte de plataforma.

--- a/docs/architecture/session-alpha-1.md
+++ b/docs/architecture/session-alpha-1.md
@@ -1,0 +1,66 @@
+# Prontidão da Sessão de digitação para `v3.0.0-alpha.1`
+
+Este registro documenta os portões técnicos do corte que conecta a nova Sessão
+de digitação ao Modo livre. Ele não publica nem promove uma versão por si só.
+
+## Escopo validado
+
+- `session` coordena captura, Motor, Documento Braille, Perfil de grafia e
+  Configuração efetiva sem depender de React ou DOM;
+- o adapter web converte apenas eventos recebidos pela região focada e preserva
+  teclas modificadas ou não mapeadas para o navegador;
+- o Modo livre produz acordes, espaço, Retrocesso, Espaçamento de linha e
+  Retorno do carro através da nova sessão;
+- as setas movem a Posição de revisão sem modificar a Posição de edição ou o
+  documento;
+- perda de foco e ocultação da página interrompem a captura conforme a política
+  efetiva e não deixam controles ativos;
+- o `textarea` temporário é uma projeção somente leitura; o `BrailleDocument`
+  mantido pela sessão é a única fonte de verdade;
+- o Modo desafio permanece no caminho legado até seu corte planejado.
+
+## Evidência automatizada
+
+O comando canônico `npm run ci` verifica formatação, lint, TypeScript estrito,
+fronteiras arquiteturais, testes, build e auditoria. A jornada automatizada do
+Modo livre verifica também:
+
+1. ausência de interceptação fora da região de captura;
+2. ativação intencional por foco;
+3. produção de acordes e espaço;
+4. Retrocesso e mudança de linha como operações distintas;
+5. navegação independente da Posição de revisão;
+6. preservação do conteúdo ao alternar apresentação e áudio;
+7. descarte de acorde incompleto após perda de foco.
+
+Os testes de `session` e do adapter usam somente `session/public.ts`. A jornada
+React usa o DOM acessível e não inspeciona estado interno.
+
+## Verificação manual
+
+Ambiente inicial: navegador desktop com teclado físico e build local da branch.
+
+1. Abrir o Modo livre e percorrer a página com `Tab`.
+2. Confirmar que a região “Área de digitação Braille” recebe foco visível e
+   anuncia “Captura ativa”.
+3. Produzir as celas `a` e `b` com `F` e com `F` + `D`; inserir espaço.
+4. Usar `Backspace`, produzir outra cela e acionar `Q` para mudar de linha.
+5. Alternar Braille/tinta com `T`, solicitar instruções com `I` e alternar os
+   sons com `O` e `M`, confirmando que o conteúdo permanece.
+6. Manter `F` pressionado, sair da região e liberar a tecla; confirmar que o
+   acorde parcial não aparece e que o estado anunciado é “Captura inativa”.
+7. Em outro controle ou fora da região, usar uma tecla não mapeada e um atalho
+   com modificador; confirmar que a página não os intercepta.
+
+Avaliações com leitores de tela, linha Braille, zoom, refluxo e cores forçadas
+continuam pertencendo aos ciclos de acessibilidade definidos para os marcos de
+release. Este corte automatiza somente os aspectos observáveis sem julgamento
+humano.
+
+## Rollback
+
+Antes da integração, a branch pode ser descartada sem afetar `develop`. Depois
+da integração, o rollback seguro é reverter integralmente o commit ou merge do
+corte e restaurar o Modo livre anterior. Não existe sincronização entre dois
+documentos: reverter troca o adapter inteiro e evita fontes de verdade
+concorrentes.

--- a/docs/architecture/session-alpha-1.md
+++ b/docs/architecture/session-alpha-1.md
@@ -15,6 +15,7 @@ de digitação ao Modo livre. Ele não publica nem promove uma versão por si s�
   documento;
 - perda de foco e ocultação da página interrompem a captura conforme a política
   efetiva e não deixam controles ativos;
+- `Escape` pausa ou retoma intencionalmente a captura focada;
 - o `textarea` temporário é uma projeção somente leitura; o `BrailleDocument`
   mantido pela sessão é a única fonte de verdade;
 - o Modo desafio permanece no caminho legado até seu corte planejado.
@@ -32,6 +33,7 @@ Modo livre verifica também:
 5. navegação independente da Posição de revisão;
 6. preservação do conteúdo ao alternar apresentação e áudio;
 7. descarte de acorde incompleto após perda de foco.
+8. pausa e retomada explícitas da captura por teclado.
 
 Os testes de `session` e do adapter usam somente `session/public.ts`. A jornada
 React usa o DOM acessível e não inspeciona estado interno.

--- a/docs/architecture/session-alpha-1.md
+++ b/docs/architecture/session-alpha-1.md
@@ -38,6 +38,24 @@ Modo livre verifica também:
 Os testes de `session` e do adapter usam somente `session/public.ts`. A jornada
 React usa o DOM acessível e não inspeciona estado interno.
 
+### Resultado registrado
+
+- data: 9 de setembro de 2026;
+- branch: `feature/free-mode-session`;
+- último commit funcional verificado: `6fb94ad`;
+- comando: `npm run ci`;
+- resultado: aprovado, com formatação, lint, TypeScript estrito, fronteiras
+  arquiteturais, testes, build e auditoria concluídos;
+- testes: 9 arquivos e 69 testes Vitest aprovados, além de 30 testes dos
+  guardrails em Node aprovados;
+- build: 126 módulos transformados e artefato Vite produzido;
+- baselines herdadas: 8 falhas de lint isoladas; auditoria com 0
+  vulnerabilidades críticas, 4 altas, 1 moderada e 0 baixas.
+
+A verificação manual abaixo não foi executada neste corte porque não havia um
+navegador disponível no ambiente do agente. Ela continua sendo um portão humano
+do marco de release e não é declarada como aprovada por esta evidência.
+
 ## Verificação manual
 
 Ambiente inicial: navegador desktop com teclado físico e build local da branch.

--- a/docs/architecture/session-alpha-1.md
+++ b/docs/architecture/session-alpha-1.md
@@ -52,9 +52,11 @@ React usa o DOM acessível e não inspeciona estado interno.
 - baselines herdadas: 8 falhas de lint isoladas; auditoria com 0
   vulnerabilidades críticas, 4 altas, 1 moderada e 0 baixas.
 
-A verificação manual abaixo não foi executada neste corte porque não havia um
-navegador disponível no ambiente do agente. Ela continua sendo um portão humano
-do marco de release e não é declarada como aprovada por esta evidência.
+A verificação manual abaixo foi executada pelo mantenedor em 9 de setembro de
+2026, após o pipeline automatizado, e a jornada foi aprovada sem problemas
+observados. Navegador, sistema operacional e tecnologias assistivas usados não
+foram registrados; por isso, essa validação não substitui a matriz completa de
+acessibilidade do marco de release.
 
 ## Verificação manual
 

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -85,6 +85,8 @@ apenas quando `handled` é verdadeiro.
 
 Teclas modificadas e não mapeadas permanecem disponíveis ao navegador. A
 repetição automática é consumida sem repetir a Intenção da máquina.
+`createDefaultWebKeyboardBindings` fornece o mapa inicial; a composição pode
+substituí-lo ou remapeá-lo antes de entregá-lo à apresentação.
 
 ## Integração temporária do Modo livre
 

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -1,0 +1,113 @@
+# Capacidade de Sessão de digitação
+
+## Responsabilidade
+
+A capacidade `session` coordena captura intencional, Motor, Documento Braille,
+Configuração efetiva da sessão e interpretação observável. Seu núcleo é puro:
+recebe `SessionInput`, devolve novo estado, snapshot e fatos semânticos e não
+depende de React, DOM, áudio ou dispositivo.
+
+O Documento Braille contido em `TypingSessionState` é a única fonte de verdade
+da produção. A Interpretação Braille existe somente como projeção derivada em
+`TypingSessionSnapshot`.
+
+## Interface pública
+
+Consumidores e testes importam somente `session/public.ts`. A interface oferece:
+
+- `createTypingSession` para criar documento, motor e captura inativa;
+- `applySessionInput` como única transição da Sessão de digitação;
+- `getTypingSessionSnapshot` para derivar o estado observável sem alterá-lo;
+- `mapWebKeyboardEvent` como adapter específico do teclado web;
+- tipos de estado, configuração, entrada, evento, resultado e snapshot.
+
+Exemplo:
+
+```ts
+import {
+    createOrthographyProfile,
+    createPaperConfiguration,
+} from '../braille/public'
+import { applySessionInput, createTypingSession } from './public'
+
+let session = createTypingSession({
+    paper: createPaperConfiguration({ type: 'continuous', columns: 40 }),
+    profile: createOrthographyProfile('portuguese-braille-2018'),
+    effectiveConfiguration: { interruptionPolicy: 'discard' },
+})
+
+session = applySessionInput(session, {
+    type: 'activate-capture',
+    source: 'web-keyboard',
+}).state
+
+session = applySessionInput(session, {
+    type: 'machine-intent',
+    source: 'web-keyboard',
+    intent: {
+        type: 'press',
+        control: { type: 'dot', dot: 1 },
+    },
+}).state
+```
+
+## Captura e interrupção
+
+- A captura começa inativa e uma Intenção da máquina fora dela produz
+  `session-input-rejected` sem alterar estado.
+- A ativação registra a fonte responsável. Outra fonte não pode assumir uma
+  captura ativa silenciosamente.
+- A UI controla a região focável e informa perda de foco, pausa ou ocultação da
+  página por `interrupt-capture`.
+- A interrupção usa `interruptionPolicy` da Configuração efetiva para confirmar
+  ou descartar o acorde incompleto, encerra controles ativos e desativa captura.
+- `move-review` altera somente a Posição de revisão e permanece independente da
+  captura, da Posição de edição e do conteúdo.
+- Eventos do Motor continuam observáveis como fatos da sessão. Operações
+  produzidas são aplicadas ao Documento Braille antes da criação do snapshot.
+
+## Adapter web de teclado
+
+`mapWebKeyboardEvent` recebe somente os campos de teclado de que necessita e
+devolve Intenções da máquina. A UI decide onde instalar os handlers e chama
+`preventDefault` apenas quando `handled` é verdadeiro.
+
+| Código físico | Controle lógico                                  |
+| ------------- | ------------------------------------------------ |
+| `F`, `D`, `S` | Pontos 1, 2 e 3                                  |
+| `J`, `K`, `L` | Pontos 4, 5 e 6                                  |
+| `Space`       | Espaço                                           |
+| `Backspace`   | Retrocesso                                       |
+| `Q`           | Espaçamento de linha seguido de Retorno do carro |
+
+Teclas modificadas e não mapeadas permanecem disponíveis ao navegador. A
+repetição automática é consumida sem repetir a Intenção da máquina.
+
+## Integração temporária do Modo livre
+
+`ui/session/FreeTypingSession.tsx` é o adapter de apresentação temporário. Ele
+controla foco, estado visual efêmero e atalhos legados, projeta o snapshot no
+`textarea` somente leitura e usa o teclado visual existente. A lista legada de
+celas não participa do Modo livre; o Modo desafio continua no caminho anterior
+até seu corte próprio.
+
+As setas enviam `move-review` diretamente à sessão; não fingem ser Controles da
+máquina. O estado acessível informa captura e Posição de revisão.
+
+## Estratégia de testes
+
+- `session.test.ts` exerce criação, captura, fonte responsável, políticas de
+  interrupção e atualização do documento pela interface pública;
+- `adapters/web/keyboard/keyboard.test.ts` verifica o contrato do adapter;
+- `tests/Journeys.test.tsx` cobre foco, teclado, controles essenciais,
+  interrupção e projeção no Modo livre pelo DOM acessível.
+
+## Referências
+
+- `CONTEXT.md`
+- `docs/adr/0001-motor-braille-como-transicao-pura.md`
+- `docs/adr/0003-sessao-de-digitacao-como-coordenadora-pura.md`
+- `docs/adr/0006-acessibilidade-como-contrato-arquitetural.md`
+- `docs/adr/0007-testes-por-interfaces-e-guardrails-continuos.md`
+- `docs/architecture/runtime-flows.md`
+- `docs/architecture/migration-plan.md`

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -38,7 +38,6 @@ let session = createTypingSession({
 
 session = applySessionInput(session, {
     type: 'activate-capture',
-    source: 'web-keyboard',
 }).state
 
 session = applySessionInput(session, {
@@ -55,8 +54,9 @@ session = applySessionInput(session, {
 
 - A captura começa inativa e uma Intenção da máquina fora dela produz
   `session-input-rejected` sem alterar estado.
-- A ativação registra a fonte responsável. Outra fonte não pode assumir uma
-  captura ativa silenciosamente.
+- O primeiro adapter que inicia um acorde torna-se responsável por ele. A posse
+  termina quando o Motor volta ao repouso, permitindo que outra fonte inicie o
+  acorde seguinte sem disputar controles ainda pressionados.
 - A UI controla a região focável e informa perda de foco, pausa ou ocultação da
   página por `interrupt-capture`.
 - A interrupção usa `interruptionPolicy` da Configuração efetiva para confirmar
@@ -69,8 +69,9 @@ session = applySessionInput(session, {
 ## Adapter web de teclado
 
 `mapWebKeyboardEvent` recebe somente os campos de teclado de que necessita e
-devolve Intenções da máquina. A UI decide onde instalar os handlers e chama
-`preventDefault` apenas quando `handled` é verdadeiro.
+devolve Intenções da máquina, o Controle lógico para apresentação visual ou um
+Comando da sessão. A UI decide onde instalar os handlers e chama `preventDefault`
+apenas quando `handled` é verdadeiro.
 
 | Código físico | Controle lógico                                  |
 | ------------- | ------------------------------------------------ |
@@ -79,17 +80,20 @@ devolve Intenções da máquina. A UI decide onde instalar os handlers e chama
 | `Space`       | Espaço                                           |
 | `Backspace`   | Retrocesso                                       |
 | `Q`           | Espaçamento de linha seguido de Retorno do carro |
+| Setas         | Movimento da Posição de revisão                  |
+| `Escape`      | Pausa ou retomada da captura                     |
 
 Teclas modificadas e não mapeadas permanecem disponíveis ao navegador. A
 repetição automática é consumida sem repetir a Intenção da máquina.
 
 ## Integração temporária do Modo livre
 
-`ui/session/FreeTypingSession.tsx` é o adapter de apresentação temporário. Ele
-controla foco, estado visual efêmero e atalhos legados, projeta o snapshot no
-`textarea` somente leitura e usa o teclado visual existente. A lista legada de
-celas não participa do Modo livre; o Modo desafio continua no caminho anterior
-até seu corte próprio.
+`views/modes/Free.tsx` compõe a sessão, o feedback legado e a apresentação.
+`ui/session/FreeTypingSession.tsx` recebe somente o snapshot e callbacks:
+controla foco e estado visual efêmero, projeta o snapshot no `textarea` somente
+leitura e usa o teclado visual existente. A lista legada de celas não participa
+do Modo livre; o Modo desafio continua no caminho anterior até seu corte
+próprio.
 
 As setas enviam `move-review` diretamente à sessão; não fingem ser Controles da
 máquina. O estado acessível informa captura e Posição de revisão.
@@ -99,7 +103,7 @@ máquina. O estado acessível informa captura e Posição de revisão.
 - `session.test.ts` exerce criação, captura, fonte responsável, políticas de
   interrupção e atualização do documento pela interface pública;
 - `adapters/web/keyboard/keyboard.test.ts` verifica o contrato do adapter;
-- `tests/Journeys.test.tsx` cobre foco, teclado, controles essenciais,
+- `tests/journeys/free-mode.test.tsx` cobre foco, teclado, controles essenciais,
   interrupção e projeção no Modo livre pelo DOM acessível.
 
 ## Referências

--- a/src/session/adapters/web/keyboard/keyboard.test.ts
+++ b/src/session/adapters/web/keyboard/keyboard.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest'
+
+import { mapWebKeyboardEvent } from '../../../public'
+
+describe('Web keyboard adapter', () => {
+    test('maps a focused Braille dot key to a normalized machine intent', () => {
+        expect(
+            mapWebKeyboardEvent(
+                {
+                    code: 'KeyF',
+                    repeat: false,
+                    ctrlKey: false,
+                    altKey: false,
+                    metaKey: false,
+                },
+                'press',
+            ),
+        ).toEqual({
+            handled: true,
+            intents: [
+                {
+                    type: 'press',
+                    control: { type: 'dot', dot: 1 },
+                },
+            ],
+        })
+    })
+
+    test('maps the legacy free-mode controls without conflating line movements', () => {
+        const event = {
+            repeat: false,
+            ctrlKey: false,
+            altKey: false,
+            metaKey: false,
+        }
+
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'Space' }, 'release'),
+        ).toEqual({
+            handled: true,
+            intents: [{ type: 'release', control: { type: 'space' } }],
+        })
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'Backspace' }, 'press'),
+        ).toEqual({
+            handled: true,
+            intents: [{ type: 'press', control: { type: 'backspace' } }],
+        })
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'KeyQ' }, 'release'),
+        ).toEqual({
+            handled: true,
+            intents: [
+                { type: 'release', control: { type: 'line-feed' } },
+                { type: 'release', control: { type: 'carriage-return' } },
+            ],
+        })
+    })
+
+    test('leaves modified and unmapped input to the browser and suppresses repeats', () => {
+        const event = {
+            code: 'KeyF',
+            repeat: false,
+            ctrlKey: false,
+            altKey: false,
+            metaKey: false,
+        }
+
+        expect(
+            mapWebKeyboardEvent({ ...event, ctrlKey: true }, 'press'),
+        ).toEqual({ handled: false, intents: [] })
+        expect(mapWebKeyboardEvent({ ...event, code: 'Tab' }, 'press')).toEqual(
+            { handled: false, intents: [] },
+        )
+        expect(
+            mapWebKeyboardEvent({ ...event, repeat: true }, 'press'),
+        ).toEqual({ handled: true, intents: [] })
+    })
+})

--- a/src/session/adapters/web/keyboard/keyboard.test.ts
+++ b/src/session/adapters/web/keyboard/keyboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest'
 
-import { mapWebKeyboardEvent } from '../../../public'
+import {
+    createDefaultWebKeyboardBindings,
+    mapWebKeyboardEvent,
+} from '../../../public'
 
 describe('Web keyboard adapter', () => {
     test('maps a focused Braille dot key to a normalized machine intent', () => {
@@ -17,6 +20,7 @@ describe('Web keyboard adapter', () => {
             ),
         ).toEqual({
             handled: true,
+            control: { type: 'dot', dot: 1 },
             intents: [
                 {
                     type: 'press',
@@ -38,18 +42,21 @@ describe('Web keyboard adapter', () => {
             mapWebKeyboardEvent({ ...event, code: 'Space' }, 'release'),
         ).toEqual({
             handled: true,
+            control: { type: 'space' },
             intents: [{ type: 'release', control: { type: 'space' } }],
         })
         expect(
             mapWebKeyboardEvent({ ...event, code: 'Backspace' }, 'press'),
         ).toEqual({
             handled: true,
+            control: { type: 'backspace' },
             intents: [{ type: 'press', control: { type: 'backspace' } }],
         })
         expect(
             mapWebKeyboardEvent({ ...event, code: 'KeyQ' }, 'release'),
         ).toEqual({
             handled: true,
+            control: { type: 'line-feed' },
             intents: [
                 { type: 'release', control: { type: 'line-feed' } },
                 { type: 'release', control: { type: 'carriage-return' } },
@@ -74,6 +81,62 @@ describe('Web keyboard adapter', () => {
         )
         expect(
             mapWebKeyboardEvent({ ...event, repeat: true }, 'press'),
-        ).toEqual({ handled: true, intents: [] })
+        ).toEqual({
+            handled: true,
+            control: { type: 'dot', dot: 1 },
+            intents: [],
+        })
+    })
+
+    test('normalizes review and capture toggle keys as session commands', () => {
+        const event = {
+            repeat: false,
+            ctrlKey: false,
+            altKey: false,
+            metaKey: false,
+        }
+
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'ArrowLeft' }, 'press'),
+        ).toEqual({
+            handled: true,
+            command: { type: 'move-review', direction: 'left' },
+            intents: [],
+        })
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'Escape' }, 'press'),
+        ).toEqual({
+            handled: true,
+            command: { type: 'toggle-capture' },
+            intents: [],
+        })
+    })
+
+    test('accepts remapped physical bindings without changing machine intents', () => {
+        const bindings = new Map(createDefaultWebKeyboardBindings())
+        const dot1 = bindings.get('KeyF')
+        bindings.delete('KeyF')
+        if (dot1 !== undefined) bindings.set('KeyA', dot1)
+        const event = {
+            repeat: false,
+            ctrlKey: false,
+            altKey: false,
+            metaKey: false,
+        }
+
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'KeyF' }, 'press', bindings),
+        ).toEqual({ handled: false, intents: [] })
+        expect(
+            mapWebKeyboardEvent({ ...event, code: 'KeyA' }, 'press', bindings),
+        ).toMatchObject({
+            handled: true,
+            intents: [
+                {
+                    type: 'press',
+                    control: { type: 'dot', dot: 1 },
+                },
+            ],
+        })
     })
 })

--- a/src/session/adapters/web/keyboard/keyboard.ts
+++ b/src/session/adapters/web/keyboard/keyboard.ts
@@ -2,6 +2,7 @@ import {
     createBrailleDot,
     type MachineControl,
     type MachineIntent,
+    type ReviewDirection,
 } from '../../../../braille/public'
 
 /** Browser keyboard data required by the web adapter. */
@@ -20,7 +21,21 @@ export type WebKeyboardEvent = Readonly<{
 export type WebKeyboardMapping = Readonly<{
     handled: boolean
     intents: readonly MachineIntent[]
+    control?: MachineControl
+    command?: WebKeyboardCommand
 }>
+
+/** A session-level command normalized from a physical keyboard event. */
+export type WebKeyboardCommand =
+    | Readonly<{ type: 'move-review'; direction: ReviewDirection }>
+    | Readonly<{ type: 'toggle-capture' }>
+
+/** Configurable physical bindings consumed by the focused web adapter. */
+export type WebKeyboardBindings = ReadonlyMap<
+    string,
+    | Readonly<{ controls: readonly MachineControl[] }>
+    | Readonly<{ command: WebKeyboardCommand }>
+>
 
 const dotByCode = new Map<string, number>([
     ['KeyF', 1],
@@ -43,12 +58,51 @@ const directControlsByCode = new Map<string, readonly MachineControl[]>([
     ],
 ])
 
+const reviewDirectionByCode = new Map<string, ReviewDirection>([
+    ['ArrowUp', 'up'],
+    ['ArrowRight', 'right'],
+    ['ArrowDown', 'down'],
+    ['ArrowLeft', 'left'],
+])
+
 const controlsForCode = (code: string): readonly MachineControl[] => {
     const dot = dotByCode.get(code)
     return dot === undefined
         ? (directControlsByCode.get(code) ?? [])
         : [Object.freeze({ type: 'dot', dot: createBrailleDot(dot) })]
 }
+
+/** Creates an independent copy of the standard free-mode key bindings. */
+export const createDefaultWebKeyboardBindings = (): WebKeyboardBindings => {
+    const bindings = new Map<
+        string,
+        | Readonly<{ controls: readonly MachineControl[] }>
+        | Readonly<{ command: WebKeyboardCommand }>
+    >()
+    for (const code of [...dotByCode.keys(), ...directControlsByCode.keys()]) {
+        bindings.set(code, Object.freeze({ controls: controlsForCode(code) }))
+    }
+    for (const [code, direction] of reviewDirectionByCode) {
+        bindings.set(
+            code,
+            Object.freeze({
+                command: Object.freeze({
+                    type: 'move-review' as const,
+                    direction,
+                }),
+            }),
+        )
+    }
+    bindings.set(
+        'Escape',
+        Object.freeze({
+            command: Object.freeze({ type: 'toggle-capture' as const }),
+        }),
+    )
+    return bindings
+}
+
+const defaultBindings = createDefaultWebKeyboardBindings()
 
 /**
  * Maps a focused browser event to device-independent machine intents.
@@ -60,21 +114,39 @@ const controlsForCode = (code: string): readonly MachineControl[] => {
 export const mapWebKeyboardEvent = (
     event: WebKeyboardEvent,
     type: 'press' | 'release',
+    bindings: WebKeyboardBindings = defaultBindings,
 ): WebKeyboardMapping => {
     if (event.ctrlKey || event.altKey || event.metaKey) {
         return Object.freeze({ handled: false, intents: Object.freeze([]) })
     }
 
-    const controls = controlsForCode(event.code)
+    const binding = bindings.get(event.code)
+    if (binding !== undefined && 'command' in binding) {
+        if (type === 'press' && !event.repeat) {
+            return Object.freeze({
+                handled: true,
+                intents: Object.freeze([]),
+                command: binding.command,
+            })
+        }
+        return Object.freeze({ handled: false, intents: Object.freeze([]) })
+    }
+
+    const controls = binding !== undefined ? binding.controls : []
     if (controls.length === 0) {
         return Object.freeze({ handled: false, intents: Object.freeze([]) })
     }
     if (type === 'press' && event.repeat) {
-        return Object.freeze({ handled: true, intents: Object.freeze([]) })
+        return Object.freeze({
+            handled: true,
+            intents: Object.freeze([]),
+            control: controls[0],
+        })
     }
 
     return Object.freeze({
         handled: true,
+        control: controls[0],
         intents: Object.freeze(
             controls.map((control) =>
                 Object.freeze({

--- a/src/session/adapters/web/keyboard/keyboard.ts
+++ b/src/session/adapters/web/keyboard/keyboard.ts
@@ -1,0 +1,87 @@
+import {
+    createBrailleDot,
+    type MachineControl,
+    type MachineIntent,
+} from '../../../../braille/public'
+
+/** Browser keyboard data required by the web adapter. */
+export type WebKeyboardEvent = Readonly<{
+    code: string
+    repeat: boolean
+    ctrlKey: boolean
+    altKey: boolean
+    metaKey: boolean
+}>
+
+/**
+ * The normalized intents and whether the focused region should consume the
+ * browser event.
+ */
+export type WebKeyboardMapping = Readonly<{
+    handled: boolean
+    intents: readonly MachineIntent[]
+}>
+
+const dotByCode = new Map<string, number>([
+    ['KeyF', 1],
+    ['KeyD', 2],
+    ['KeyS', 3],
+    ['KeyJ', 4],
+    ['KeyK', 5],
+    ['KeyL', 6],
+])
+
+const directControlsByCode = new Map<string, readonly MachineControl[]>([
+    ['Space', [Object.freeze({ type: 'space' })]],
+    ['Backspace', [Object.freeze({ type: 'backspace' })]],
+    [
+        'KeyQ',
+        [
+            Object.freeze({ type: 'line-feed' }),
+            Object.freeze({ type: 'carriage-return' }),
+        ],
+    ],
+])
+
+const controlsForCode = (code: string): readonly MachineControl[] => {
+    const dot = dotByCode.get(code)
+    return dot === undefined
+        ? (directControlsByCode.get(code) ?? [])
+        : [Object.freeze({ type: 'dot', dot: createBrailleDot(dot) })]
+}
+
+/**
+ * Maps a focused browser event to device-independent machine intents.
+ *
+ * Modified and unmapped keys remain unhandled. Repeated keydown events are
+ * handled without repeating an intent. `KeyQ` preserves the legacy new-line
+ * control while producing distinct line-feed and carriage-return operations.
+ */
+export const mapWebKeyboardEvent = (
+    event: WebKeyboardEvent,
+    type: 'press' | 'release',
+): WebKeyboardMapping => {
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+        return Object.freeze({ handled: false, intents: Object.freeze([]) })
+    }
+
+    const controls = controlsForCode(event.code)
+    if (controls.length === 0) {
+        return Object.freeze({ handled: false, intents: Object.freeze([]) })
+    }
+    if (type === 'press' && event.repeat) {
+        return Object.freeze({ handled: true, intents: Object.freeze([]) })
+    }
+
+    return Object.freeze({
+        handled: true,
+        intents: Object.freeze(
+            controls.map((control) =>
+                Object.freeze({
+                    type,
+                    control,
+                }),
+            ),
+        ),
+    })
+}

--- a/src/session/public.ts
+++ b/src/session/public.ts
@@ -1,0 +1,19 @@
+export {
+    applySessionInput,
+    createTypingSession,
+    getTypingSessionSnapshot,
+    type CaptureState,
+    type EffectiveSessionConfiguration,
+    type SessionEvent,
+    type SessionInput,
+    type SessionInputSource,
+    type TypingSessionResult,
+    type TypingSessionOptions,
+    type TypingSessionSnapshot,
+    type TypingSessionState,
+} from './session'
+export {
+    mapWebKeyboardEvent,
+    type WebKeyboardEvent,
+    type WebKeyboardMapping,
+} from './adapters/web/keyboard/keyboard'

--- a/src/session/public.ts
+++ b/src/session/public.ts
@@ -14,6 +14,9 @@ export {
 } from './session'
 export {
     mapWebKeyboardEvent,
+    createDefaultWebKeyboardBindings,
+    type WebKeyboardBindings,
     type WebKeyboardEvent,
     type WebKeyboardMapping,
+    type WebKeyboardCommand,
 } from './adapters/web/keyboard/keyboard'

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -35,7 +35,6 @@ const createConfirmingSession = () =>
 const activateKeyboardCapture = (state: TypingSessionState) =>
     applySessionInput(state, {
         type: 'activate-capture',
-        source: 'web-keyboard',
     }).state
 
 describe('Typing session', () => {
@@ -67,10 +66,7 @@ describe('Typing session', () => {
                 reason: 'capture-inactive',
             },
         ])
-        expect(released.snapshot.capture).toEqual({
-            status: 'active',
-            source: 'web-keyboard',
-        })
+        expect(released.snapshot.capture).toEqual({ status: 'active' })
         expect(
             getDocumentCellImpression(released.state.document, {
                 sheet: 0,
@@ -129,21 +125,48 @@ describe('Typing session', () => {
         ])
     })
 
-    test('keeps the active input source responsible for capture', () => {
+    test('keeps the initiating source responsible only until its chord ends', () => {
         const active = activateKeyboardCapture(createSession())
-
-        const rejected = applySessionInput(active, {
-            type: 'activate-capture',
-            source: 'another-input-adapter',
+        const dot1 = createBrailleDot(1)
+        const pressed = applySessionInput(active, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: { type: 'press', control: { type: 'dot', dot: dot1 } },
+        })
+        const rejected = applySessionInput(pressed.state, {
+            type: 'machine-intent',
+            source: 'assisted-composition',
+            intent: {
+                type: 'press',
+                control: { type: 'dot', dot: createBrailleDot(2) },
+            },
+        })
+        const released = applySessionInput(rejected.state, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: { type: 'release', control: { type: 'dot', dot: dot1 } },
+        })
+        const nextSource = applySessionInput(released.state, {
+            type: 'machine-intent',
+            source: 'assisted-composition',
+            intent: {
+                type: 'press',
+                control: { type: 'dot', dot: createBrailleDot(2) },
+            },
         })
 
-        expect(rejected.state).toBe(active)
+        expect(rejected.state).toBe(pressed.state)
         expect(rejected.events).toEqual([
             {
                 type: 'session-input-rejected',
                 reason: 'source-not-responsible',
             },
         ])
+        expect(released.snapshot.capture).toEqual({ status: 'active' })
+        expect(nextSource.snapshot.capture).toEqual({
+            status: 'active',
+            owner: 'assisted-composition',
+        })
     })
 
     test('confirms an unfinished chord when required by effective configuration', () => {

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+    createBrailleDot,
+    createOrthographyProfile,
+    createPaperConfiguration,
+    getDocumentCellImpression,
+} from '../braille/public'
+import {
+    applySessionInput,
+    createTypingSession,
+    type TypingSessionState,
+} from './public'
+
+const createSession = () =>
+    createTypingSession({
+        paper: createPaperConfiguration({
+            type: 'continuous',
+            columns: 20,
+        }),
+        profile: createOrthographyProfile('portuguese-braille-2018'),
+        effectiveConfiguration: { interruptionPolicy: 'discard' },
+    })
+
+const createConfirmingSession = () =>
+    createTypingSession({
+        paper: createPaperConfiguration({
+            type: 'continuous',
+            columns: 20,
+        }),
+        profile: createOrthographyProfile('portuguese-braille-2018'),
+        effectiveConfiguration: { interruptionPolicy: 'confirm' },
+    })
+
+const activateKeyboardCapture = (state: TypingSessionState) =>
+    applySessionInput(state, {
+        type: 'activate-capture',
+        source: 'web-keyboard',
+    }).state
+
+describe('Typing session', () => {
+    test('requires intentional capture before producing a Braille cell', () => {
+        const initial = createSession()
+        const dot = createBrailleDot(1)
+
+        const ignored = applySessionInput(initial, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: { type: 'press', control: { type: 'dot', dot } },
+        })
+        const active = activateKeyboardCapture(ignored.state)
+        const pressed = applySessionInput(active, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: { type: 'press', control: { type: 'dot', dot } },
+        })
+        const released = applySessionInput(pressed.state, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: { type: 'release', control: { type: 'dot', dot } },
+        })
+
+        expect(ignored.state).toBe(initial)
+        expect(ignored.events).toEqual([
+            {
+                type: 'session-input-rejected',
+                reason: 'capture-inactive',
+            },
+        ])
+        expect(released.snapshot.capture).toEqual({
+            status: 'active',
+            source: 'web-keyboard',
+        })
+        expect(
+            getDocumentCellImpression(released.state.document, {
+                sheet: 0,
+                row: 0,
+                column: 0,
+            }),
+        ).toEqual({ cell: { dots: [1] }, erasedDots: [] })
+        expect(released.snapshot.interpretation.lines).toEqual([
+            {
+                segments: [
+                    {
+                        status: 'interpreted',
+                        role: 'symbol',
+                        text: 'a',
+                        source: [{ sheet: 0, row: 0, column: 0 }],
+                    },
+                ],
+            },
+        ])
+    })
+
+    test('interrupts capture with the effective discard policy', () => {
+        const active = activateKeyboardCapture(createSession())
+        const pressed = applySessionInput(active, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: {
+                type: 'press',
+                control: { type: 'dot', dot: createBrailleDot(1) },
+            },
+        })
+
+        const interrupted = applySessionInput(pressed.state, {
+            type: 'interrupt-capture',
+            cause: 'focus-loss',
+        })
+
+        expect(interrupted.snapshot.capture).toEqual({ status: 'inactive' })
+        expect(interrupted.state.engine).toEqual({
+            accumulatedDots: [],
+            pressedDots: [],
+            pressedControls: [],
+        })
+        expect(interrupted.snapshot.document).toBe(active.document)
+        expect(interrupted.events).toEqual([
+            {
+                type: 'chord-discarded',
+                cause: 'interruption',
+                cell: { dots: [1] },
+            },
+            {
+                type: 'capture-interrupted',
+                cause: 'focus-loss',
+                policy: 'discard',
+            },
+        ])
+    })
+
+    test('keeps the active input source responsible for capture', () => {
+        const active = activateKeyboardCapture(createSession())
+
+        const rejected = applySessionInput(active, {
+            type: 'activate-capture',
+            source: 'another-input-adapter',
+        })
+
+        expect(rejected.state).toBe(active)
+        expect(rejected.events).toEqual([
+            {
+                type: 'session-input-rejected',
+                reason: 'source-not-responsible',
+            },
+        ])
+    })
+
+    test('confirms an unfinished chord when required by effective configuration', () => {
+        const active = activateKeyboardCapture(createConfirmingSession())
+        const pressed = applySessionInput(active, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: {
+                type: 'press',
+                control: { type: 'dot', dot: createBrailleDot(1) },
+            },
+        })
+
+        const interrupted = applySessionInput(pressed.state, {
+            type: 'interrupt-capture',
+            cause: 'page-hidden',
+        })
+
+        expect(
+            getDocumentCellImpression(interrupted.state.document, {
+                sheet: 0,
+                row: 0,
+                column: 0,
+            }),
+        ).toEqual({ cell: { dots: [1] }, erasedDots: [] })
+        expect(interrupted.events.at(-1)).toEqual({
+            type: 'capture-interrupted',
+            cause: 'page-hidden',
+            policy: 'confirm',
+        })
+    })
+
+    test('moves the review position without changing editing or content', () => {
+        const active = activateKeyboardCapture(createSession())
+        const pressed = applySessionInput(active, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: {
+                type: 'press',
+                control: { type: 'dot', dot: createBrailleDot(1) },
+            },
+        })
+        const written = applySessionInput(pressed.state, {
+            type: 'machine-intent',
+            source: 'web-keyboard',
+            intent: {
+                type: 'release',
+                control: { type: 'dot', dot: createBrailleDot(1) },
+            },
+        })
+
+        const reviewed = applySessionInput(written.state, {
+            type: 'move-review',
+            direction: 'right',
+        })
+
+        expect(reviewed.state.document.editingPosition).toEqual({
+            sheet: 0,
+            row: 0,
+            column: 1,
+        })
+        expect(reviewed.state.document.reviewPosition).toEqual({
+            sheet: 0,
+            row: 0,
+            column: 1,
+        })
+        expect(reviewed.events).toEqual([
+            {
+                type: 'review-position-moved',
+                direction: 'right',
+                position: { sheet: 0, row: 0, column: 1 },
+            },
+        ])
+        expect(reviewed.snapshot.interpretation).toEqual(
+            written.snapshot.interpretation,
+        )
+    })
+})

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -1,0 +1,294 @@
+import {
+    applyDocumentOperation,
+    applyIntent,
+    createBrailleDocument,
+    createEngineState,
+    interpretBrailleDocument,
+    moveReviewPosition,
+    type BrailleDocument,
+    type BrailleInterpretation,
+    type EngineEvent,
+    type EngineState,
+    type MachineIntent,
+    type OrthographyProfile,
+    type PaperConfiguration,
+    type ReviewDirection,
+} from '../braille/public'
+
+/** A stable identifier supplied by an input adapter. */
+export type SessionInputSource = string
+
+/** Policies in force for this session after experience requirements are applied. */
+export type EffectiveSessionConfiguration = Readonly<{
+    interruptionPolicy: 'discard' | 'confirm'
+}>
+
+/** Whether an input source currently owns intentional machine capture. */
+export type CaptureState =
+    | Readonly<{ status: 'inactive' }>
+    | Readonly<{
+          status: 'active'
+          source: SessionInputSource
+      }>
+
+/**
+ * The immutable source of truth for one typing session.
+ *
+ * Interpretation is derived in the snapshot and is never stored alongside the
+ * Braille document.
+ */
+export type TypingSessionState = Readonly<{
+    engine: EngineState
+    document: BrailleDocument
+    profile: OrthographyProfile
+    effectiveConfiguration: EffectiveSessionConfiguration
+    capture: CaptureState
+}>
+
+/** A normalized request accepted by the typing session transition. */
+export type SessionInput =
+    | Readonly<{
+          type: 'activate-capture'
+          source: SessionInputSource
+      }>
+    | Readonly<{
+          type: 'machine-intent'
+          source: SessionInputSource
+          intent: MachineIntent
+      }>
+    | Readonly<{
+          type: 'interrupt-capture'
+          cause: 'focus-loss' | 'page-hidden' | 'pause'
+      }>
+    | Readonly<{
+          type: 'move-review'
+          direction: ReviewDirection
+      }>
+
+/** A semantic fact exposed to presentation and feedback consumers. */
+export type SessionEvent =
+    | EngineEvent
+    | Readonly<{
+          type: 'capture-activated'
+          source: SessionInputSource
+      }>
+    | Readonly<{
+          type: 'session-input-rejected'
+          reason: 'capture-inactive' | 'source-not-responsible'
+      }>
+    | Readonly<{
+          type: 'capture-interrupted'
+          cause: 'focus-loss' | 'page-hidden' | 'pause'
+          policy: EffectiveSessionConfiguration['interruptionPolicy']
+      }>
+    | Readonly<{
+          type: 'review-position-moved'
+          direction: ReviewDirection
+          position: BrailleDocument['reviewPosition']
+      }>
+
+/** The immutable observable projection returned to session consumers. */
+export type TypingSessionSnapshot = Readonly<{
+    document: BrailleDocument
+    interpretation: BrailleInterpretation
+    effectiveConfiguration: EffectiveSessionConfiguration
+    capture: CaptureState
+}>
+
+/** The state, observable projection, and facts produced by one transition. */
+export type TypingSessionResult = Readonly<{
+    state: TypingSessionState
+    snapshot: TypingSessionSnapshot
+    events: readonly SessionEvent[]
+}>
+
+/** Required initial document and effective policy choices for a session. */
+export type TypingSessionOptions = Readonly<{
+    paper: PaperConfiguration
+    profile: OrthographyProfile
+    effectiveConfiguration: EffectiveSessionConfiguration
+}>
+
+const inactiveCapture = (): CaptureState =>
+    Object.freeze({ status: 'inactive' })
+
+const freezeState = (
+    engine: EngineState,
+    document: BrailleDocument,
+    profile: OrthographyProfile,
+    effectiveConfiguration: EffectiveSessionConfiguration,
+    capture: CaptureState,
+): TypingSessionState =>
+    Object.freeze({
+        engine,
+        document,
+        profile,
+        effectiveConfiguration,
+        capture,
+    })
+
+const createSnapshot = (state: TypingSessionState): TypingSessionSnapshot =>
+    Object.freeze({
+        document: state.document,
+        interpretation: interpretBrailleDocument(state.document, state.profile),
+        effectiveConfiguration: state.effectiveConfiguration,
+        capture: state.capture,
+    })
+
+/** Returns the immutable observable projection of a typing session. */
+export const getTypingSessionSnapshot = createSnapshot
+
+const createResult = (
+    state: TypingSessionState,
+    events: readonly SessionEvent[] = [],
+): TypingSessionResult =>
+    Object.freeze({
+        state,
+        snapshot: createSnapshot(state),
+        events: Object.freeze([...events]),
+    })
+
+const applyMachineTransition = (
+    state: TypingSessionState,
+    intent: MachineIntent,
+    capture: CaptureState,
+    sessionEvents: readonly SessionEvent[] = [],
+): TypingSessionResult => {
+    const engineResult = applyIntent(state.engine, intent)
+    const document = engineResult.events.reduce(
+        (current, event) =>
+            event.type === 'operation-produced'
+                ? applyDocumentOperation(current, event.operation)
+                : current,
+        state.document,
+    )
+    return createResult(
+        freezeState(
+            engineResult.state,
+            document,
+            state.profile,
+            state.effectiveConfiguration,
+            capture,
+        ),
+        [...engineResult.events, ...sessionEvents],
+    )
+}
+
+/**
+ * Creates an inactive typing session at the first writable document position.
+ *
+ * Capture must be activated intentionally before machine intents can change the
+ * engine or document.
+ */
+export const createTypingSession = (
+    options: TypingSessionOptions,
+): TypingSessionState =>
+    freezeState(
+        createEngineState(),
+        createBrailleDocument(options.paper),
+        options.profile,
+        Object.freeze({ ...options.effectiveConfiguration }),
+        inactiveCapture(),
+    )
+
+/**
+ * Applies one session input as a pure transition.
+ *
+ * Machine operations update the Braille document before the snapshot is
+ * derived. Inputs from an inactive or non-responsible source preserve state and
+ * produce `session-input-rejected`. Interruption applies the effective policy,
+ * clears every active control, and deactivates capture.
+ */
+export const applySessionInput = (
+    state: TypingSessionState,
+    input: SessionInput,
+): TypingSessionResult => {
+    if (input.type === 'activate-capture') {
+        if (state.capture.status === 'active') {
+            if (state.capture.source === input.source)
+                return createResult(state)
+            return createResult(state, [
+                Object.freeze({
+                    type: 'session-input-rejected',
+                    reason: 'source-not-responsible',
+                }),
+            ])
+        }
+        const capture = Object.freeze({
+            status: 'active' as const,
+            source: input.source,
+        })
+        return createResult(
+            freezeState(
+                state.engine,
+                state.document,
+                state.profile,
+                state.effectiveConfiguration,
+                capture,
+            ),
+            [
+                Object.freeze({
+                    type: 'capture-activated',
+                    source: input.source,
+                }),
+            ],
+        )
+    }
+
+    if (input.type === 'interrupt-capture') {
+        if (state.capture.status === 'inactive') return createResult(state)
+
+        const policy = state.effectiveConfiguration.interruptionPolicy
+        return applyMachineTransition(
+            state,
+            { type: 'interrupt-capture', policy },
+            inactiveCapture(),
+            [
+                Object.freeze({
+                    type: 'capture-interrupted',
+                    cause: input.cause,
+                    policy,
+                }),
+            ],
+        )
+    }
+
+    if (input.type === 'move-review') {
+        const document = moveReviewPosition(state.document, input.direction)
+        return createResult(
+            freezeState(
+                state.engine,
+                document,
+                state.profile,
+                state.effectiveConfiguration,
+                state.capture,
+            ),
+            [
+                Object.freeze({
+                    type: 'review-position-moved',
+                    direction: input.direction,
+                    position: document.reviewPosition,
+                }),
+            ],
+        )
+    }
+
+    if (state.capture.status === 'inactive') {
+        return createResult(state, [
+            Object.freeze({
+                type: 'session-input-rejected',
+                reason: 'capture-inactive',
+            }),
+        ])
+    }
+    if (state.capture.source !== input.source) {
+        return createResult(state, [
+            Object.freeze({
+                type: 'session-input-rejected',
+                reason: 'source-not-responsible',
+            }),
+        ])
+    }
+
+    return applyMachineTransition(state, input.intent, state.capture)
+}

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -15,20 +15,20 @@ import {
     type ReviewDirection,
 } from '../braille/public'
 
-/** A stable identifier supplied by an input adapter. */
-export type SessionInputSource = string
+/** The input adapters allowed to participate in chord ownership. */
+export type SessionInputSource = 'web-keyboard' | 'assisted-composition'
 
 /** Policies in force for this session after experience requirements are applied. */
 export type EffectiveSessionConfiguration = Readonly<{
     interruptionPolicy: 'discard' | 'confirm'
 }>
 
-/** Whether an input source currently owns intentional machine capture. */
+/** Whether capture is inactive or active, optionally with a chord owner. */
 export type CaptureState =
     | Readonly<{ status: 'inactive' }>
     | Readonly<{
           status: 'active'
-          source: SessionInputSource
+          owner?: SessionInputSource
       }>
 
 /**
@@ -49,7 +49,6 @@ export type TypingSessionState = Readonly<{
 export type SessionInput =
     | Readonly<{
           type: 'activate-capture'
-          source: SessionInputSource
       }>
     | Readonly<{
           type: 'machine-intent'
@@ -70,7 +69,6 @@ export type SessionEvent =
     | EngineEvent
     | Readonly<{
           type: 'capture-activated'
-          source: SessionInputSource
       }>
     | Readonly<{
           type: 'session-input-rejected'
@@ -111,6 +109,16 @@ export type TypingSessionOptions = Readonly<{
 
 const inactiveCapture = (): CaptureState =>
     Object.freeze({ status: 'inactive' })
+
+const activeCapture = (owner?: SessionInputSource): CaptureState =>
+    owner === undefined
+        ? Object.freeze({ status: 'active' })
+        : Object.freeze({ status: 'active', owner })
+
+const engineIsIdle = (engine: EngineState) =>
+    engine.accumulatedDots.length === 0 &&
+    engine.pressedDots.length === 0 &&
+    engine.pressedControls.length === 0
 
 const freezeState = (
     engine: EngineState,
@@ -196,7 +204,8 @@ export const createTypingSession = (
  *
  * Machine operations update the Braille document before the snapshot is
  * derived. Inputs from an inactive or non-responsible source preserve state and
- * produce `session-input-rejected`. Interruption applies the effective policy,
+ * produce `session-input-rejected`. The source that starts a chord owns it
+ * until the engine becomes idle. Interruption applies the effective policy,
  * clears every active control, and deactivates capture.
  */
 export const applySessionInput = (
@@ -204,20 +213,8 @@ export const applySessionInput = (
     input: SessionInput,
 ): TypingSessionResult => {
     if (input.type === 'activate-capture') {
-        if (state.capture.status === 'active') {
-            if (state.capture.source === input.source)
-                return createResult(state)
-            return createResult(state, [
-                Object.freeze({
-                    type: 'session-input-rejected',
-                    reason: 'source-not-responsible',
-                }),
-            ])
-        }
-        const capture = Object.freeze({
-            status: 'active' as const,
-            source: input.source,
-        })
+        if (state.capture.status === 'active') return createResult(state)
+        const capture = activeCapture()
         return createResult(
             freezeState(
                 state.engine,
@@ -226,12 +223,7 @@ export const applySessionInput = (
                 state.effectiveConfiguration,
                 capture,
             ),
-            [
-                Object.freeze({
-                    type: 'capture-activated',
-                    source: input.source,
-                }),
-            ],
+            [Object.freeze({ type: 'capture-activated' })],
         )
     }
 
@@ -281,7 +273,10 @@ export const applySessionInput = (
             }),
         ])
     }
-    if (state.capture.source !== input.source) {
+    if (
+        state.capture.owner !== undefined &&
+        state.capture.owner !== input.source
+    ) {
         return createResult(state, [
             Object.freeze({
                 type: 'session-input-rejected',
@@ -290,5 +285,26 @@ export const applySessionInput = (
         ])
     }
 
-    return applyMachineTransition(state, input.intent, state.capture)
+    const owner = state.capture.owner ?? input.source
+    const engineResult = applyIntent(state.engine, input.intent)
+    const capture = engineIsIdle(engineResult.state)
+        ? activeCapture()
+        : activeCapture(owner)
+    const document = engineResult.events.reduce(
+        (current, event) =>
+            event.type === 'operation-produced'
+                ? applyDocumentOperation(current, event.operation)
+                : current,
+        state.document,
+    )
+    return createResult(
+        freezeState(
+            engineResult.state,
+            document,
+            state.profile,
+            state.effectiveConfiguration,
+            capture,
+        ),
+        engineResult.events,
+    )
 }

--- a/src/tests/Journeys.test.tsx
+++ b/src/tests/Journeys.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import AudioProvider from '../providers/AudioProvider'
 import Home from '../views/Home'
 import Challenge from '../views/modes/Challenge'
-import Free from '../views/modes/Free'
 
 class AudioStub {
     static instances: AudioStub[] = []
@@ -100,66 +99,6 @@ test('home offers free and challenge modes through focusable links with audio', 
         expect(audioEndingWith('modo-livre.mp3')?.play).toHaveBeenCalled()
         expect(audioEndingWith('modo-desafio.mp3')?.play).toHaveBeenCalled()
     })
-})
-
-test('free mode produces content and preserves output across presentation and audio changes', async () => {
-    renderWithAudio(<Free />)
-    const typewriter = screen.getByRole('region', {
-        name: 'Área de digitação Braille',
-    })
-    const output = screen.getByRole('textbox') as HTMLTextAreaElement
-
-    expect(fireEvent.keyDown(document.body, { code: 'KeyF' })).toBe(true)
-    expect(output).toHaveValue('')
-
-    fireEvent.focus(typewriter)
-    press(typewriter, 'KeyF')
-    press(typewriter, 'Space')
-    press(typewriter, 'Backspace')
-    chord(typewriter, ['KeyF', 'KeyD'])
-    press(typewriter, 'Space')
-    press(typewriter, 'KeyQ')
-    press(typewriter, 'KeyJ')
-    press(typewriter, 'KeyT')
-    press(typewriter, 'KeyO')
-    press(typewriter, 'KeyM')
-    press(typewriter, 'KeyI')
-
-    expect(output).toHaveValue('ab_\n^')
-    expect(output).toHaveAttribute('readonly')
-    expect(output).not.toHaveClass('braille')
-    await waitFor(() => {
-        expect(
-            audioEndingWith('instrucoes-modo-livre.mp3')?.play,
-        ).toHaveBeenCalled()
-    })
-})
-
-test('free mode interrupts an unfinished chord when its capture region loses focus', () => {
-    renderWithAudio(<Free />)
-    const typewriter = screen.getByRole('region', {
-        name: 'Área de digitação Braille',
-    })
-    const output = screen.getByRole('textbox')
-    const captureStatus = screen.getByRole('status')
-
-    expect(captureStatus).toHaveTextContent('Captura inativa')
-    fireEvent.focus(typewriter)
-    expect(captureStatus).toHaveTextContent('Captura ativa')
-
-    fireEvent.keyDown(typewriter, { code: 'KeyF' })
-    fireEvent.blur(typewriter, { relatedTarget: document.body })
-    fireEvent.keyUp(typewriter, { code: 'KeyF' })
-
-    expect(captureStatus).toHaveTextContent('Captura inativa')
-    expect(output).toHaveValue('')
-
-    fireEvent.focus(typewriter)
-    press(typewriter, 'KeyF')
-    expect(output).toHaveValue('a')
-
-    press(typewriter, 'ArrowRight')
-    expect(captureStatus).toHaveTextContent('revisão: linha 1, coluna 2')
 })
 
 test('challenge mode reports errors and advances after a correct chord response', async () => {

--- a/src/tests/Journeys.test.tsx
+++ b/src/tests/Journeys.test.tsx
@@ -103,25 +103,63 @@ test('home offers free and challenge modes through focusable links with audio', 
 })
 
 test('free mode produces content and preserves output across presentation and audio changes', async () => {
-    const { container } = renderWithAudio(<Free />)
-    const typewriter = container.querySelector('#typewriter') as HTMLElement
+    renderWithAudio(<Free />)
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
     const output = screen.getByRole('textbox') as HTMLTextAreaElement
 
+    expect(fireEvent.keyDown(document.body, { code: 'KeyF' })).toBe(true)
+    expect(output).toHaveValue('')
+
+    fireEvent.focus(typewriter)
     press(typewriter, 'KeyF')
     press(typewriter, 'Space')
+    press(typewriter, 'Backspace')
+    chord(typewriter, ['KeyF', 'KeyD'])
+    press(typewriter, 'Space')
     press(typewriter, 'KeyQ')
+    press(typewriter, 'KeyJ')
     press(typewriter, 'KeyT')
     press(typewriter, 'KeyO')
     press(typewriter, 'KeyM')
     press(typewriter, 'KeyI')
 
-    expect(output).toHaveValue('a_\n')
+    expect(output).toHaveValue('ab_\n^')
+    expect(output).toHaveAttribute('readonly')
     expect(output).not.toHaveClass('braille')
     await waitFor(() => {
         expect(
             audioEndingWith('instrucoes-modo-livre.mp3')?.play,
         ).toHaveBeenCalled()
     })
+})
+
+test('free mode interrupts an unfinished chord when its capture region loses focus', () => {
+    renderWithAudio(<Free />)
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+    const output = screen.getByRole('textbox')
+    const captureStatus = screen.getByRole('status')
+
+    expect(captureStatus).toHaveTextContent('Captura inativa')
+    fireEvent.focus(typewriter)
+    expect(captureStatus).toHaveTextContent('Captura ativa')
+
+    fireEvent.keyDown(typewriter, { code: 'KeyF' })
+    fireEvent.blur(typewriter, { relatedTarget: document.body })
+    fireEvent.keyUp(typewriter, { code: 'KeyF' })
+
+    expect(captureStatus).toHaveTextContent('Captura inativa')
+    expect(output).toHaveValue('')
+
+    fireEvent.focus(typewriter)
+    press(typewriter, 'KeyF')
+    expect(output).toHaveValue('a')
+
+    press(typewriter, 'ArrowRight')
+    expect(captureStatus).toHaveTextContent('revisão: linha 1, coluna 2')
 })
 
 test('challenge mode reports errors and advances after a correct chord response', async () => {

--- a/src/ui/public.ts
+++ b/src/ui/public.ts
@@ -1,2 +1,3 @@
 export { default as FreeTypingSession } from './session/FreeTypingSession'
 export type { FreeTypingSessionProps } from './session/FreeTypingSession'
+export type { LegacyFreeModeAction } from './session/legacyFreeModeKeyboard'

--- a/src/ui/public.ts
+++ b/src/ui/public.ts
@@ -1,0 +1,2 @@
+export { default as FreeTypingSession } from './session/FreeTypingSession'
+export type { FreeTypingSessionProps } from './session/FreeTypingSession'

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -1,43 +1,21 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { FocusEvent, KeyboardEvent } from 'react'
 
-import {
-    createOrthographyProfile,
-    createPaperConfiguration,
-} from '../../braille/public'
+import type { MachineControl } from '../../braille/public'
 import Keyboard from '../../components/Keyboard'
 import { Cell, cellToString } from '../../domain/Cell'
 import { Key } from '../../domain/Key'
-import { useAudioContext } from '../../providers/AudioProvider'
 import {
-    applySessionInput,
-    createTypingSession,
-    getTypingSessionSnapshot,
     mapWebKeyboardEvent,
     type SessionInput,
-    type TypingSessionState,
+    type TypingSessionSnapshot,
 } from '../../session/public'
+import {
+    legacyFreeModeActionForKey,
+    type LegacyFreeModeAction,
+} from './legacyFreeModeKeyboard'
 
 const keyboardSource = 'web-keyboard'
-
-const createFreeSession = () =>
-    createTypingSession({
-        paper: createPaperConfiguration({
-            type: 'continuous',
-            columns: 40,
-        }),
-        profile: createOrthographyProfile('portuguese-braille-2018'),
-        effectiveConfiguration: { interruptionPolicy: 'discard' },
-    })
-
-const applyInputs = (
-    state: TypingSessionState,
-    inputs: readonly SessionInput[],
-) =>
-    inputs.reduce(
-        (current, input) => applySessionInput(current, input).state,
-        state,
-    )
 
 const initialKeyStatus = {
     [Key.DOT1]: false,
@@ -51,30 +29,26 @@ const initialKeyStatus = {
     [Key.BACKSPACE]: false,
 }
 
-const visualKeyByCode = new Map<string, keyof typeof initialKeyStatus>([
-    ['KeyF', Key.DOT1],
-    ['KeyD', Key.DOT2],
-    ['KeyS', Key.DOT3],
-    ['KeyJ', Key.DOT4],
-    ['KeyK', Key.DOT5],
-    ['KeyL', Key.DOT6],
-    ['Space', Key.SPACE],
-    ['KeyQ', Key.ENTER],
-    ['Backspace', Key.BACKSPACE],
-])
+const visualKeyForControl = (
+    control: MachineControl,
+): keyof typeof initialKeyStatus => {
+    if (control.type === 'dot') {
+        const dotKeys: ReadonlyArray<keyof typeof initialKeyStatus> = [
+            Key.DOT1,
+            Key.DOT2,
+            Key.DOT3,
+            Key.DOT4,
+            Key.DOT5,
+            Key.DOT6,
+        ]
+        return dotKeys[control.dot - 1]
+    }
+    if (control.type === 'space') return Key.SPACE
+    if (control.type === 'backspace') return Key.BACKSPACE
+    return Key.ENTER
+}
 
-const reviewDirectionByCode: ReadonlyMap<
-    string,
-    'up' | 'right' | 'down' | 'left'
-> = new Map([
-    ['ArrowUp', 'up'],
-    ['ArrowRight', 'right'],
-    ['ArrowDown', 'down'],
-    ['ArrowLeft', 'left'],
-])
-
-const legacyText = (state: TypingSessionState) => {
-    const snapshot = getTypingSessionSnapshot(state)
+const legacyText = (snapshot: TypingSessionSnapshot) => {
     const rows: string[][] = []
     const paper = snapshot.document.paper
     const absoluteRow = (sheet: number, row: number) =>
@@ -103,34 +77,24 @@ const legacyText = (state: TypingSessionState) => {
 
 /** Temporary legacy-presentation callbacks for the modern free typing session. */
 export type FreeTypingSessionProps = Readonly<{
-    onInstructionsRequested: () => void
+    snapshot: TypingSessionSnapshot
+    dispatch: (input: SessionInput) => void
+    onPresentationAction: (action: LegacyFreeModeAction) => void
+    onMachineKeyPressed: () => void
 }>
 
 export default function FreeTypingSession({
-    onInstructionsRequested,
+    snapshot,
+    dispatch,
+    onPresentationAction,
+    onMachineKeyPressed,
 }: FreeTypingSessionProps) {
-    const [session, setSession] = useState(createFreeSession)
     const [showBraille, setShowBraille] = useState(true)
     const [, setOutputMuted] = useState(false)
     const [keyboardMuted, setKeyboardMuted] = useState(false)
     const [keyStatus, setKeyStatus] = useState(initialKeyStatus)
-    const {
-        playKeyPress,
-        playKeyboardMuted,
-        playKeyboardUnmuted,
-        playOutputMuted,
-        playOutputUnmuted,
-        playBrailleViewAudio,
-        playInkViewAudio,
-    } = useAudioContext()
 
-    const output = useMemo(() => legacyText(session), [session])
-
-    const dispatch = useCallback(
-        (input: SessionInput) =>
-            setSession((current) => applySessionInput(current, input).state),
-        [],
-    )
+    const output = useMemo(() => legacyText(snapshot), [snapshot])
 
     const interrupt = useCallback(
         (cause: 'focus-loss' | 'page-hidden' | 'pause') =>
@@ -150,8 +114,13 @@ export default function FreeTypingSession({
             )
     }, [interrupt])
 
-    const handleFocus = () =>
-        dispatch({ type: 'activate-capture', source: keyboardSource })
+    useEffect(() => {
+        if (snapshot.capture.status === 'inactive') {
+            setKeyStatus(initialKeyStatus)
+        }
+    }, [snapshot.capture.status])
+
+    const handleFocus = () => dispatch({ type: 'activate-capture' })
 
     const handleBlur = (event: FocusEvent<HTMLElement>) => {
         if (!event.currentTarget.contains(event.relatedTarget)) {
@@ -160,45 +129,16 @@ export default function FreeTypingSession({
     }
 
     const handlePresentationKey = (event: KeyboardEvent<HTMLElement>) => {
-        if (event.repeat || event.ctrlKey || event.altKey || event.metaKey) {
-            return false
-        }
-        if (event.code === 'KeyI') {
-            event.preventDefault()
-            onInstructionsRequested()
-            return true
-        }
-        if (event.code === 'KeyT') {
-            event.preventDefault()
-            setShowBraille((current) => {
-                current ? playInkViewAudio() : playBrailleViewAudio()
-                return !current
-            })
-            return true
-        }
-        if (event.code === 'KeyO') {
-            event.preventDefault()
-            setOutputMuted((current) => {
-                current ? playOutputUnmuted() : playOutputMuted()
-                return !current
-            })
-            return true
-        }
-        if (event.code === 'KeyM') {
-            event.preventDefault()
-            setKeyboardMuted((current) => {
-                current ? playKeyboardUnmuted() : playKeyboardMuted()
-                return !current
-            })
-            return true
-        }
-        const reviewDirection = reviewDirectionByCode.get(event.code)
-        if (reviewDirection !== undefined) {
-            event.preventDefault()
-            dispatch({ type: 'move-review', direction: reviewDirection })
-            return true
-        }
-        return false
+        const action = legacyFreeModeActionForKey(event)
+        if (action === undefined) return false
+        event.preventDefault()
+        if (action === 'view-toggled') setShowBraille((current) => !current)
+        if (action === 'output-audio-toggled')
+            setOutputMuted((current) => !current)
+        if (action === 'keyboard-audio-toggled')
+            setKeyboardMuted((current) => !current)
+        onPresentationAction(action)
+        return true
     }
 
     const handleKeyboardEvent = (
@@ -211,24 +151,29 @@ export default function FreeTypingSession({
         if (!mapping.handled) return
         event.preventDefault()
 
-        const visualKey = visualKeyByCode.get(event.code)
-        if (visualKey !== undefined) {
+        if (mapping.control !== undefined) {
+            const visualKey = visualKeyForControl(mapping.control)
             setKeyStatus((current) => ({
                 ...current,
                 [visualKey]: type === 'press',
             }))
         }
-        if (type === 'press' && !event.repeat && !keyboardMuted) playKeyPress()
+        if (type === 'press' && !event.repeat && !keyboardMuted)
+            onMachineKeyPressed()
 
-        setSession((current) =>
-            applyInputs(
-                current,
-                mapping.intents.map((intent) => ({
-                    type: 'machine-intent',
-                    source: keyboardSource,
-                    intent,
-                })),
-            ),
+        if (mapping.command?.type === 'move-review') {
+            dispatch(mapping.command)
+        } else if (mapping.command?.type === 'toggle-capture') {
+            snapshot.capture.status === 'active'
+                ? interrupt('pause')
+                : dispatch({ type: 'activate-capture' })
+        }
+        mapping.intents.forEach((intent) =>
+            dispatch({
+                type: 'machine-intent',
+                source: keyboardSource,
+                intent,
+            }),
         )
     }
 
@@ -246,11 +191,11 @@ export default function FreeTypingSession({
         >
             <div className="fs-1">MODO LIVRE</div>
             <div role="status" aria-live="polite">
-                {session.capture.status === 'active'
+                {snapshot.capture.status === 'active'
                     ? 'Captura ativa'
                     : 'Captura inativa'}{' '}
-                — revisão: linha {session.document.reviewPosition.row + 1},
-                coluna {session.document.reviewPosition.column + 1}
+                — revisão: linha {snapshot.document.reviewPosition.row + 1},
+                coluna {snapshot.document.reviewPosition.column + 1}
             </div>
             <div className="d-flex justify-content-center w-100 fs-5 gap-3 mb-3">
                 <div>
@@ -264,6 +209,9 @@ export default function FreeTypingSession({
                 </div>
                 <div>
                     <strong>(m)</strong> Liga/desliga áudio do teclado
+                </div>
+                <div>
+                    <strong>(Esc)</strong> Pausa/retoma a captura
                 </div>
             </div>
             <textarea

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -1,0 +1,289 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FocusEvent, KeyboardEvent } from 'react'
+
+import {
+    createOrthographyProfile,
+    createPaperConfiguration,
+} from '../../braille/public'
+import Keyboard from '../../components/Keyboard'
+import { Cell, cellToString } from '../../domain/Cell'
+import { Key } from '../../domain/Key'
+import { useAudioContext } from '../../providers/AudioProvider'
+import {
+    applySessionInput,
+    createTypingSession,
+    getTypingSessionSnapshot,
+    mapWebKeyboardEvent,
+    type SessionInput,
+    type TypingSessionState,
+} from '../../session/public'
+
+const keyboardSource = 'web-keyboard'
+
+const createFreeSession = () =>
+    createTypingSession({
+        paper: createPaperConfiguration({
+            type: 'continuous',
+            columns: 40,
+        }),
+        profile: createOrthographyProfile('portuguese-braille-2018'),
+        effectiveConfiguration: { interruptionPolicy: 'discard' },
+    })
+
+const applyInputs = (
+    state: TypingSessionState,
+    inputs: readonly SessionInput[],
+) =>
+    inputs.reduce(
+        (current, input) => applySessionInput(current, input).state,
+        state,
+    )
+
+const initialKeyStatus = {
+    [Key.DOT1]: false,
+    [Key.DOT2]: false,
+    [Key.DOT3]: false,
+    [Key.DOT4]: false,
+    [Key.DOT5]: false,
+    [Key.DOT6]: false,
+    [Key.SPACE]: false,
+    [Key.ENTER]: false,
+    [Key.BACKSPACE]: false,
+}
+
+const visualKeyByCode = new Map<string, keyof typeof initialKeyStatus>([
+    ['KeyF', Key.DOT1],
+    ['KeyD', Key.DOT2],
+    ['KeyS', Key.DOT3],
+    ['KeyJ', Key.DOT4],
+    ['KeyK', Key.DOT5],
+    ['KeyL', Key.DOT6],
+    ['Space', Key.SPACE],
+    ['KeyQ', Key.ENTER],
+    ['Backspace', Key.BACKSPACE],
+])
+
+const reviewDirectionByCode: ReadonlyMap<
+    string,
+    'up' | 'right' | 'down' | 'left'
+> = new Map([
+    ['ArrowUp', 'up'],
+    ['ArrowRight', 'right'],
+    ['ArrowDown', 'down'],
+    ['ArrowLeft', 'left'],
+])
+
+const legacyText = (state: TypingSessionState) => {
+    const snapshot = getTypingSessionSnapshot(state)
+    const rows: string[][] = []
+    const paper = snapshot.document.paper
+    const absoluteRow = (sheet: number, row: number) =>
+        paper.type === 'sheet' ? sheet * paper.rows + row : row
+
+    snapshot.document.grids.forEach((grid, sheet) => {
+        grid.impressions.forEach(({ position, impression }) => {
+            const row = absoluteRow(sheet, position.row)
+            const cells = rows[row] ?? []
+            const cellName = `C${impression.cell.dots.join('') || '0'}`
+            const legacyCell = (Cell as unknown as Record<string, Cell>)[
+                cellName
+            ]
+            cells[position.column - paper.margins.left] =
+                cellToString(legacyCell)
+            rows[row] = cells
+        })
+    })
+    const editingRow = absoluteRow(
+        snapshot.document.editingPosition.sheet,
+        snapshot.document.editingPosition.row,
+    )
+    while (rows.length <= editingRow) rows.push([])
+    return rows.map((cells) => cells.join('')).join('\n')
+}
+
+/** Temporary legacy-presentation callbacks for the modern free typing session. */
+export type FreeTypingSessionProps = Readonly<{
+    onInstructionsRequested: () => void
+}>
+
+export default function FreeTypingSession({
+    onInstructionsRequested,
+}: FreeTypingSessionProps) {
+    const [session, setSession] = useState(createFreeSession)
+    const [showBraille, setShowBraille] = useState(true)
+    const [, setOutputMuted] = useState(false)
+    const [keyboardMuted, setKeyboardMuted] = useState(false)
+    const [keyStatus, setKeyStatus] = useState(initialKeyStatus)
+    const {
+        playKeyPress,
+        playKeyboardMuted,
+        playKeyboardUnmuted,
+        playOutputMuted,
+        playOutputUnmuted,
+        playBrailleViewAudio,
+        playInkViewAudio,
+    } = useAudioContext()
+
+    const output = useMemo(() => legacyText(session), [session])
+
+    const dispatch = useCallback(
+        (input: SessionInput) =>
+            setSession((current) => applySessionInput(current, input).state),
+        [],
+    )
+
+    const interrupt = useCallback(
+        (cause: 'focus-loss' | 'page-hidden' | 'pause') =>
+            dispatch({ type: 'interrupt-capture', cause }),
+        [dispatch],
+    )
+
+    useEffect(() => {
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') interrupt('page-hidden')
+        }
+        document.addEventListener('visibilitychange', handleVisibilityChange)
+        return () =>
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange,
+            )
+    }, [interrupt])
+
+    const handleFocus = () =>
+        dispatch({ type: 'activate-capture', source: keyboardSource })
+
+    const handleBlur = (event: FocusEvent<HTMLElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+            interrupt('focus-loss')
+        }
+    }
+
+    const handlePresentationKey = (event: KeyboardEvent<HTMLElement>) => {
+        if (event.repeat || event.ctrlKey || event.altKey || event.metaKey) {
+            return false
+        }
+        if (event.code === 'KeyI') {
+            event.preventDefault()
+            onInstructionsRequested()
+            return true
+        }
+        if (event.code === 'KeyT') {
+            event.preventDefault()
+            setShowBraille((current) => {
+                current ? playInkViewAudio() : playBrailleViewAudio()
+                return !current
+            })
+            return true
+        }
+        if (event.code === 'KeyO') {
+            event.preventDefault()
+            setOutputMuted((current) => {
+                current ? playOutputUnmuted() : playOutputMuted()
+                return !current
+            })
+            return true
+        }
+        if (event.code === 'KeyM') {
+            event.preventDefault()
+            setKeyboardMuted((current) => {
+                current ? playKeyboardUnmuted() : playKeyboardMuted()
+                return !current
+            })
+            return true
+        }
+        const reviewDirection = reviewDirectionByCode.get(event.code)
+        if (reviewDirection !== undefined) {
+            event.preventDefault()
+            dispatch({ type: 'move-review', direction: reviewDirection })
+            return true
+        }
+        return false
+    }
+
+    const handleKeyboardEvent = (
+        event: KeyboardEvent<HTMLElement>,
+        type: 'press' | 'release',
+    ) => {
+        if (type === 'press' && handlePresentationKey(event)) return
+
+        const mapping = mapWebKeyboardEvent(event, type)
+        if (!mapping.handled) return
+        event.preventDefault()
+
+        const visualKey = visualKeyByCode.get(event.code)
+        if (visualKey !== undefined) {
+            setKeyStatus((current) => ({
+                ...current,
+                [visualKey]: type === 'press',
+            }))
+        }
+        if (type === 'press' && !event.repeat && !keyboardMuted) playKeyPress()
+
+        setSession((current) =>
+            applyInputs(
+                current,
+                mapping.intents.map((intent) => ({
+                    type: 'machine-intent',
+                    source: keyboardSource,
+                    intent,
+                })),
+            ),
+        )
+    }
+
+    return (
+        <div
+            id="typewriter"
+            className="container d-flex flex-column justify-content-center align-items-center"
+            role="region"
+            aria-label="Área de digitação Braille"
+            tabIndex={0}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={(event) => handleKeyboardEvent(event, 'press')}
+            onKeyUp={(event) => handleKeyboardEvent(event, 'release')}
+        >
+            <div className="fs-1">MODO LIVRE</div>
+            <div role="status" aria-live="polite">
+                {session.capture.status === 'active'
+                    ? 'Captura ativa'
+                    : 'Captura inativa'}{' '}
+                — revisão: linha {session.document.reviewPosition.row + 1},
+                coluna {session.document.reviewPosition.column + 1}
+            </div>
+            <div className="d-flex justify-content-center w-100 fs-5 gap-3 mb-3">
+                <div>
+                    <strong>(i)</strong> Instruções
+                </div>
+                <div>
+                    <strong>(t)</strong> Ver texto a tinta ou em Braille
+                </div>
+                <div>
+                    <strong>(o)</strong> Liga/desliga áudio do conversor
+                </div>
+                <div>
+                    <strong>(m)</strong> Liga/desliga áudio do teclado
+                </div>
+            </div>
+            <textarea
+                aria-label="Saída de Celas Braille digitadas"
+                className={`form-control p-5 mb-3 ${showBraille ? 'braille' : ''}`}
+                readOnly
+                rows={3}
+                value={output}
+                spellCheck={false}
+                tabIndex={-1}
+                style={{
+                    height: '400px',
+                    letterSpacing: '15px',
+                    fontSize: '4rem',
+                    textWrap: 'wrap',
+                    overflowY: 'scroll',
+                    overflow: 'hidden',
+                }}
+            />
+            <Keyboard keyStatus={keyStatus} />
+        </div>
+    )
+}

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -9,6 +9,7 @@ import {
     mapWebKeyboardEvent,
     type SessionInput,
     type TypingSessionSnapshot,
+    type WebKeyboardBindings,
 } from '../../session/public'
 import {
     legacyFreeModeActionForKey,
@@ -79,6 +80,7 @@ const legacyText = (snapshot: TypingSessionSnapshot) => {
 export type FreeTypingSessionProps = Readonly<{
     snapshot: TypingSessionSnapshot
     dispatch: (input: SessionInput) => void
+    keyboardBindings: WebKeyboardBindings
     onPresentationAction: (action: LegacyFreeModeAction) => void
     onMachineKeyPressed: () => void
 }>
@@ -86,6 +88,7 @@ export type FreeTypingSessionProps = Readonly<{
 export default function FreeTypingSession({
     snapshot,
     dispatch,
+    keyboardBindings,
     onPresentationAction,
     onMachineKeyPressed,
 }: FreeTypingSessionProps) {
@@ -147,7 +150,7 @@ export default function FreeTypingSession({
     ) => {
         if (type === 'press' && handlePresentationKey(event)) return
 
-        const mapping = mapWebKeyboardEvent(event, type)
+        const mapping = mapWebKeyboardEvent(event, type, keyboardBindings)
         if (!mapping.handled) return
         event.preventDefault()
 

--- a/src/ui/session/legacyFreeModeKeyboard.ts
+++ b/src/ui/session/legacyFreeModeKeyboard.ts
@@ -1,0 +1,27 @@
+/** Presentation actions retained by the temporary legacy free-mode adapter. */
+export type LegacyFreeModeAction =
+    | 'instructions-requested'
+    | 'view-toggled'
+    | 'output-audio-toggled'
+    | 'keyboard-audio-toggled'
+
+const actionByCode = new Map<string, LegacyFreeModeAction>([
+    ['KeyI', 'instructions-requested'],
+    ['KeyT', 'view-toggled'],
+    ['KeyO', 'output-audio-toggled'],
+    ['KeyM', 'keyboard-audio-toggled'],
+])
+
+/** Converts a plain keyboard event into a legacy presentation action. */
+export const legacyFreeModeActionForKey = (
+    event: Readonly<{
+        code: string
+        repeat: boolean
+        ctrlKey: boolean
+        altKey: boolean
+        metaKey: boolean
+    }>,
+): LegacyFreeModeAction | undefined =>
+    event.repeat || event.ctrlKey || event.altKey || event.metaKey
+        ? undefined
+        : actionByCode.get(event.code)

--- a/src/views/modes/Free.tsx
+++ b/src/views/modes/Free.tsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 
 import '../../styles/views/modes/Free.css'
 
-import Typewriter from '../../components/Typewriter'
 import { useAudioContext } from '../../providers/AudioProvider'
+import { FreeTypingSession } from '../../ui/public'
 
 export default function Free() {
-    const output = useRef<HTMLTextAreaElement>(null)
     const { playHowToAccessInstructionsAudio, playFreeModeInstructionsAudio } =
         useAudioContext()
 
@@ -17,15 +16,8 @@ export default function Free() {
     return (
         <>
             <main>
-                <Typewriter
-                    outputReference={output}
-                    challengeMode={false}
-                    randomWord={undefined}
-                    onEnterPressed={() => {}}
-                    onInstructionsKeyPressed={() => {
-                        playFreeModeInstructionsAudio()
-                    }}
-                    onRepeatWordKeyPressed={() => {}}
+                <FreeTypingSession
+                    onInstructionsRequested={playFreeModeInstructionsAudio}
                 />
             </main>
         </>

--- a/src/views/modes/Free.tsx
+++ b/src/views/modes/Free.tsx
@@ -1,23 +1,93 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import '../../styles/views/modes/Free.css'
 
 import { useAudioContext } from '../../providers/AudioProvider'
-import { FreeTypingSession } from '../../ui/public'
+import {
+    createOrthographyProfile,
+    createPaperConfiguration,
+} from '../../braille/public'
+import {
+    applySessionInput,
+    createTypingSession,
+    getTypingSessionSnapshot,
+    type SessionInput,
+} from '../../session/public'
+import { FreeTypingSession, type LegacyFreeModeAction } from '../../ui/public'
+
+const createFreeSession = () =>
+    createTypingSession({
+        paper: createPaperConfiguration({
+            type: 'continuous',
+            columns: 40,
+        }),
+        profile: createOrthographyProfile('portuguese-braille-2018'),
+        effectiveConfiguration: { interruptionPolicy: 'discard' },
+    })
 
 export default function Free() {
-    const { playHowToAccessInstructionsAudio, playFreeModeInstructionsAudio } =
-        useAudioContext()
+    const [session, setSession] = useState(createFreeSession)
+    const snapshot = useMemo(() => getTypingSessionSnapshot(session), [session])
+    const {
+        playHowToAccessInstructionsAudio,
+        playFreeModeInstructionsAudio,
+        playKeyPress,
+        playKeyboardMuted,
+        playKeyboardUnmuted,
+        playOutputMuted,
+        playOutputUnmuted,
+        playBrailleViewAudio,
+        playInkViewAudio,
+    } = useAudioContext()
+    const [showingBraille, setShowingBraille] = useState(true)
+    const [outputMuted, setOutputMuted] = useState(false)
+    const [keyboardMuted, setKeyboardMuted] = useState(false)
 
     useEffect(() => {
         playHowToAccessInstructionsAudio(() => {})
     }, [])
 
+    const dispatch = useCallback((input: SessionInput) => {
+        setSession((current) => applySessionInput(current, input).state)
+    }, [])
+
+    const handlePresentationAction = useCallback(
+        (action: LegacyFreeModeAction) => {
+            if (action === 'instructions-requested') {
+                playFreeModeInstructionsAudio()
+            } else if (action === 'view-toggled') {
+                showingBraille ? playInkViewAudio() : playBrailleViewAudio()
+                setShowingBraille((current) => !current)
+            } else if (action === 'output-audio-toggled') {
+                outputMuted ? playOutputUnmuted() : playOutputMuted()
+                setOutputMuted((current) => !current)
+            } else {
+                keyboardMuted ? playKeyboardUnmuted() : playKeyboardMuted()
+                setKeyboardMuted((current) => !current)
+            }
+        },
+        [
+            keyboardMuted,
+            outputMuted,
+            playBrailleViewAudio,
+            playFreeModeInstructionsAudio,
+            playInkViewAudio,
+            playKeyboardMuted,
+            playKeyboardUnmuted,
+            playOutputMuted,
+            playOutputUnmuted,
+            showingBraille,
+        ],
+    )
+
     return (
         <>
             <main>
                 <FreeTypingSession
-                    onInstructionsRequested={playFreeModeInstructionsAudio}
+                    snapshot={snapshot}
+                    dispatch={dispatch}
+                    onPresentationAction={handlePresentationAction}
+                    onMachineKeyPressed={playKeyPress}
                 />
             </main>
         </>

--- a/src/views/modes/Free.tsx
+++ b/src/views/modes/Free.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../braille/public'
 import {
     applySessionInput,
+    createDefaultWebKeyboardBindings,
     createTypingSession,
     getTypingSessionSnapshot,
     type SessionInput,
@@ -28,6 +29,7 @@ const createFreeSession = () =>
 export default function Free() {
     const [session, setSession] = useState(createFreeSession)
     const snapshot = useMemo(() => getTypingSessionSnapshot(session), [session])
+    const keyboardBindings = useMemo(createDefaultWebKeyboardBindings, [])
     const {
         playHowToAccessInstructionsAudio,
         playFreeModeInstructionsAudio,
@@ -86,6 +88,7 @@ export default function Free() {
                 <FreeTypingSession
                     snapshot={snapshot}
                     dispatch={dispatch}
+                    keyboardBindings={keyboardBindings}
                     onPresentationAction={handlePresentationAction}
                     onMachineKeyPressed={playKeyPress}
                 />

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import AudioProvider from '../../src/providers/AudioProvider'
+import Free from '../../src/views/modes/Free'
+
+class AudioStub {
+    static instances: AudioStub[] = []
+
+    currentTime = 0
+    onended: null | (() => void) = null
+    pause = vi.fn()
+    play = vi.fn().mockResolvedValue(undefined)
+
+    constructor(public src: string) {
+        AudioStub.instances.push(this)
+    }
+}
+
+const renderFreeMode = () =>
+    render(
+        <AudioProvider>
+            <MemoryRouter>
+                <Free />
+            </MemoryRouter>
+        </AudioProvider>,
+    )
+
+const press = (target: Element, code: string) => {
+    fireEvent.keyDown(target, { code })
+    fireEvent.keyUp(target, { code })
+}
+
+const chord = (target: Element, codes: string[]) => {
+    codes.forEach((code) => fireEvent.keyDown(target, { code }))
+    codes.forEach((code) => fireEvent.keyUp(target, { code }))
+}
+
+const audioEndingWith = (path: string) =>
+    AudioStub.instances.find((audio) => audio.src.endsWith(path))
+
+beforeEach(() => {
+    AudioStub.instances = []
+    globalThis.Audio = AudioStub as unknown as typeof Audio
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+test('Modo livre digita pelo teclado focado sem criar outra fonte de verdade', async () => {
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+    const output = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    expect(fireEvent.keyDown(document.body, { code: 'KeyF' })).toBe(true)
+    expect(output).toHaveValue('')
+
+    fireEvent.focus(typewriter)
+    press(typewriter, 'KeyF')
+    press(typewriter, 'Space')
+    press(typewriter, 'Backspace')
+    chord(typewriter, ['KeyF', 'KeyD'])
+    press(typewriter, 'Space')
+    press(typewriter, 'KeyQ')
+    press(typewriter, 'KeyJ')
+    press(typewriter, 'KeyT')
+    press(typewriter, 'KeyO')
+    press(typewriter, 'KeyM')
+    press(typewriter, 'KeyI')
+
+    expect(output).toHaveValue('ab_\n^')
+    expect(output).toHaveAttribute('readonly')
+    expect(output).not.toHaveClass('braille')
+    await waitFor(() => {
+        expect(
+            audioEndingWith('instrucoes-modo-livre.mp3')?.play,
+        ).toHaveBeenCalled()
+    })
+})
+
+test('Modo livre interrompe acorde incompleto e permite pausar a captura', () => {
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+    const output = screen.getByRole('textbox')
+    const captureStatus = screen.getByRole('status')
+
+    expect(captureStatus).toHaveTextContent('Captura inativa')
+    fireEvent.focus(typewriter)
+    fireEvent.keyDown(typewriter, { code: 'KeyF' })
+    fireEvent.blur(typewriter, { relatedTarget: document.body })
+    fireEvent.keyUp(typewriter, { code: 'KeyF' })
+
+    expect(captureStatus).toHaveTextContent('Captura inativa')
+    expect(output).toHaveValue('')
+
+    fireEvent.focus(typewriter)
+    press(typewriter, 'KeyF')
+    press(typewriter, 'ArrowRight')
+    expect(output).toHaveValue('a')
+    expect(captureStatus).toHaveTextContent('revisão: linha 1, coluna 2')
+
+    press(typewriter, 'Escape')
+    expect(captureStatus).toHaveTextContent('Captura inativa')
+    press(typewriter, 'Escape')
+    expect(captureStatus).toHaveTextContent('Captura ativa')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
         "strict": true,
         "target": "ES2022"
     },
-    "include": ["src"]
+    "include": ["src", "tests"]
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         globals: true,
-        include: ['src/**/*.test.{ts,tsx}'],
+        include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.test.{ts,tsx}'],
         setupFiles: ['./src/tests/setup.ts'],
     },
 })


### PR DESCRIPTION
## Resumo

- conecta o Modo livre ao novo Motor, Documento Braille e Sessão de digitação
- adiciona captura focada, posse por acorde, interrupção, pausa/retomada e revisão
- mantém a apresentação legada como adapter temporário e o Documento Braille como fonte única
- adiciona testes unitários e jornadas acessíveis permanentes
- registra os portões automatizados e a validação manual

## Validação

- npm run ci
- validação manual pelo mantenedor

Closes #41