### PR TITLE
fix(release): aceita prefixo v na tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,9 @@ jobs:
                   import { readFile } from 'node:fs/promises'
 
                   const tag = process.env.RELEASE_TAG
+                  const version = tag.startsWith('v') ? tag.slice(1) : tag
                   const changelog = await readFile('CHANGELOG.md', 'utf8')
-                  const header = `## [${tag}] - `
+                  const header = `## [${version}] - `
 
                   if (!changelog.includes(header)) {
                     throw new Error(


### PR DESCRIPTION
Corrige a validação do workflow de releases: tags Git usam o prefixo v, enquanto cabeçalhos do Keep a Changelog não usam. O workflow passa a comparar a versão normalizada.