### PR TITLE
feat(preferences): persiste escolhas do Modo livre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
 
 ## [Unreleased]
 
+### Added
+
+- Preferências do simulador versionadas, validadas e persistidas no Modo livre,
+  com migração explícita, fallback seguro e adapters web e determinístico.
+
 ## [3.0.0-alpha.1] - 2026-09-09
 
 ### Added

--- a/config/lint-baseline.json
+++ b/config/lint-baseline.json
@@ -15,7 +15,6 @@
         "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
         "src/views/Home.tsx:@typescript-eslint/no-unused-vars:'handleBtnAboutFocused' is defined but never used.",
         "src/views/Home.tsx:react-hooks/exhaustive-deps:React Hook useEffect has a missing dependency: 'playMainMenuAudio'. Either include it or remove the dependency array.",
-        "src/views/modes/Challenge.tsx:react-hooks/exhaustive-deps:React Hook useEffect has missing dependencies: 'playHowToAccessInstructionsAudio' and 'playRandomWordAudio'. Either include them or remove the dependency array.",
-        "src/views/modes/Free.tsx:react-hooks/exhaustive-deps:React Hook useEffect has a missing dependency: 'playHowToAccessInstructionsAudio'. Either include it or remove the dependency array."
+        "src/views/modes/Challenge.tsx:react-hooks/exhaustive-deps:React Hook useEffect has missing dependencies: 'playHowToAccessInstructionsAudio' and 'playRandomWordAudio'. Either include them or remove the dependency array."
     ]
 }

--- a/src/app/pages/FreePage.tsx
+++ b/src/app/pages/FreePage.tsx
@@ -40,7 +40,7 @@ const createFreeSession = (preferences: SimulatorPreferences) =>
         ).configuration,
     })
 
-export default function Free() {
+export default function FreePage() {
     const preferencesStorage = useMemo(createLocalStoragePreferencesStorage, [])
     const [initialPreferences] = useState(() =>
         loadSimulatorPreferences(preferencesStorage),
@@ -48,12 +48,19 @@ export default function Free() {
     const [preferences, setPreferences] = useState(
         initialPreferences.preferences,
     )
-    const [preferencesNotice, setPreferencesNotice] = useState(() =>
-        initialPreferences.reason === 'invalid' ||
-        initialPreferences.reason === 'unavailable'
+    const [preferencesNotice, setPreferencesNotice] = useState(() => {
+        if (
+            initialPreferences.status === 'migrated' &&
+            initialPreferences.migrationPersistence === 'failed'
+        ) {
+            return 'As preferências antigas foram aplicadas nesta sessão, mas não puderam ser atualizadas no armazenamento.'
+        }
+        return 'reason' in initialPreferences &&
+            (initialPreferences.reason === 'invalid' ||
+                initialPreferences.reason === 'unavailable')
             ? 'As preferências salvas não puderam ser carregadas; os padrões foram aplicados.'
-            : undefined,
-    )
+            : undefined
+    })
     const [session, setSession] = useState(() =>
         createFreeSession(initialPreferences.preferences),
     )

--- a/src/app/public.ts
+++ b/src/app/public.ts
@@ -1,0 +1,1 @@
+export { default as FreePage } from './pages/FreePage'

--- a/src/bootstrap.jsx
+++ b/src/bootstrap.jsx
@@ -6,7 +6,7 @@ import './styles/index.css'
 import './vendors/bootstrap/css/bootstrap.min.css'
 
 import Home from './views/Home'
-import Free from './views/modes/Free'
+import { FreePage } from './app/public'
 
 import 'bootstrap/dist/js/bootstrap.bundle.js'
 import AudioProvider from './providers/AudioProvider'
@@ -18,7 +18,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <HashRouter>
                 <Routes>
                     <Route path="/" Component={Home} />
-                    <Route path="/free" Component={Free} />
+                    <Route path="/free" Component={FreePage} />
                     <Route path="/lessons" Component={Challenge} />
                 </Routes>
             </HashRouter>

--- a/src/preferences/README.md
+++ b/src/preferences/README.md
@@ -43,6 +43,10 @@ e JSON inválido não atravessam a interface. Falhas de leitura e escrita são
 convertidas em resultados; elas não interrompem nem revertem a Sessão de
 digitação corrente.
 
+Uma migração válida tenta gravar imediatamente o schema atual. Se essa gravação
+falhar, as escolhas migradas continuam ativas na sessão corrente e o resultado
+expõe `migrationPersistence: 'failed'`.
+
 ## Configuração efetiva
 
 O Modo de simulação define a política permanente atualmente suportada:
@@ -57,6 +61,12 @@ O adapter web usa a chave estável `den-braille-typewriter.preferences` no
 `localStorage`; a versão fica dentro do payload para permitir migrações sem
 trocar silenciosamente de namespace. O adapter de memória é determinístico e
 serve ao mesmo contrato sem depender do navegador.
+
+Neste corte, os atalhos do Modo livre permitem alterar e persistir as escolhas
+de apresentação e áudio. Bindings e Modo de simulação já são validados,
+carregados e aplicados quando presentes no snapshot, mas sua edição por uma
+interface própria pertence à evolução planejada da apresentação de
+preferências.
 
 ## Estratégia de testes
 

--- a/src/preferences/README.md
+++ b/src/preferences/README.md
@@ -1,0 +1,77 @@
+# Capacidade de Preferências do simulador
+
+## Responsabilidade
+
+A capacidade `preferences` define as escolhas permanentes da pessoa, valida e
+migra seu formato serializado e oferece uma seam pequena para carregamento e
+persistência. Ela não conhece React, Sessão de digitação, Documento Braille,
+áudio nem APIs do navegador.
+
+O schema atual, identificado por `version: 1`, preserva:
+
+- visualização Braille ou a tinta;
+- áudio da saída e do teclado;
+- códigos físicos associados aos controles configuráveis;
+- Modo de simulação Assistido ou Fidelidade física.
+
+## Interface pública
+
+Consumidores e testes importam somente `preferences/public.ts`. A interface
+oferece:
+
+- `createDefaultSimulatorPreferences` para criar um snapshot válido;
+- `loadSimulatorPreferences` para carregar, validar, migrar ou aplicar fallback;
+- `saveSimulatorPreferences` para persistir sem propagar falhas do adapter;
+- `applySimulatorPreferenceChange` para produzir um novo snapshot imutável;
+- `resolveEffectiveSessionConfiguration` para combinar preferências e Requisitos
+  da experiência sem alterar escolhas permanentes;
+- adapters de memória e de armazenamento local web para a mesma
+  `PreferencesStorage`.
+
+## Carregamento, migração e fallback
+
+O carregamento sempre devolve preferências válidas e um resultado observável:
+
+| Status      | Significado                                                            |
+| ----------- | ---------------------------------------------------------------------- |
+| `loaded`    | O payload da versão atual foi validado.                                |
+| `migrated`  | Escolhas legadas da versão 0 foram convertidas para a versão atual.    |
+| `defaulted` | Os padrões foram usados por ausência, invalidade ou indisponibilidade. |
+
+Payloads incompletos, códigos físicos vazios ou duplicados, versões desconhecidas
+e JSON inválido não atravessam a interface. Falhas de leitura e escrita são
+convertidas em resultados; elas não interrompem nem revertem a Sessão de
+digitação corrente.
+
+## Configuração efetiva
+
+O Modo de simulação define a política permanente atualmente suportada:
+Assistido descarta um acorde interrompido e Fidelidade física o confirma. Um
+Requisito da experiência pode substituir essa política somente no resultado de
+`resolveEffectiveSessionConfiguration`. O snapshot persistido permanece
+inalterado, e `overriddenPreferences` torna a substituição observável.
+
+## Adapters
+
+O adapter web usa a chave estável `den-braille-typewriter.preferences` no
+`localStorage`; a versão fica dentro do payload para permitir migrações sem
+trocar silenciosamente de namespace. O adapter de memória é determinístico e
+serve ao mesmo contrato sem depender do navegador.
+
+## Estratégia de testes
+
+- `preferences.test.ts` verifica valores válidos, migração, fallback, mudanças
+  imutáveis e Configuração efetiva pela interface pública;
+- `tests/contracts/preferences-storage.test.ts` aplica o mesmo contrato aos
+  adapters web e de memória;
+- `tests/journeys/free-mode.test.tsx` verifica persistência entre Sessões de
+  digitação, bindings carregados e continuidade após falha de escrita.
+
+## Referências
+
+- `CONTEXT.md`
+- `docs/adr/0003-sessao-de-digitacao-como-coordenadora-pura.md`
+- `docs/adr/0004-experiencias-compoem-sessoes-independentes.md`
+- `docs/adr/0006-acessibilidade-como-contrato-arquitetural.md`
+- `docs/architecture/modules.md`
+- `docs/architecture/migration-plan.md`

--- a/src/preferences/adapters/memory/memory.ts
+++ b/src/preferences/adapters/memory/memory.ts
@@ -1,0 +1,14 @@
+import type { PreferencesStorage } from '../../preferences'
+
+/** Creates an isolated deterministic preferences adapter. */
+export const createMemoryPreferencesStorage = (
+    initialValue: string | null = null,
+): PreferencesStorage => {
+    let value = initialValue
+    return Object.freeze({
+        read: () => value,
+        write: (serialized: string) => {
+            value = serialized
+        },
+    })
+}

--- a/src/preferences/adapters/web/local-storage/localStorage.ts
+++ b/src/preferences/adapters/web/local-storage/localStorage.ts
@@ -11,10 +11,16 @@ export const simulatorPreferencesStorageKey =
 
 /** Adapts browser local storage to the simulator-preferences storage seam. */
 export const createLocalStoragePreferencesStorage = (
-    storage: WebStorage = globalThis.localStorage,
-    key: string = simulatorPreferencesStorageKey,
+    storage?: WebStorage,
 ): PreferencesStorage =>
     Object.freeze({
-        read: () => storage.getItem(key),
-        write: (serialized: string) => storage.setItem(key, serialized),
+        read: () =>
+            (storage ?? globalThis.localStorage).getItem(
+                simulatorPreferencesStorageKey,
+            ),
+        write: (serialized: string) =>
+            (storage ?? globalThis.localStorage).setItem(
+                simulatorPreferencesStorageKey,
+                serialized,
+            ),
     })

--- a/src/preferences/adapters/web/local-storage/localStorage.ts
+++ b/src/preferences/adapters/web/local-storage/localStorage.ts
@@ -1,0 +1,20 @@
+import type { PreferencesStorage } from '../../../preferences'
+
+/** Browser storage operations required by the local-storage adapter. */
+export type WebStorage = Readonly<{
+    getItem: (key: string) => string | null
+    setItem: (key: string, value: string) => void
+}>
+
+export const simulatorPreferencesStorageKey =
+    'den-braille-typewriter.preferences'
+
+/** Adapts browser local storage to the simulator-preferences storage seam. */
+export const createLocalStoragePreferencesStorage = (
+    storage: WebStorage = globalThis.localStorage,
+    key: string = simulatorPreferencesStorageKey,
+): PreferencesStorage =>
+    Object.freeze({
+        read: () => storage.getItem(key),
+        write: (serialized: string) => storage.setItem(key, serialized),
+    })

--- a/src/preferences/preferences.test.ts
+++ b/src/preferences/preferences.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+    applySimulatorPreferenceChange,
+    createDefaultSimulatorPreferences,
+    loadSimulatorPreferences,
+    resolveEffectiveSessionConfiguration,
+    saveSimulatorPreferences,
+} from './public'
+
+describe('Simulator preferences', () => {
+    test('uses an explicit fallback when persisted data is missing', () => {
+        const result = loadSimulatorPreferences({
+            read: () => null,
+            write: () => undefined,
+        })
+
+        expect(result).toEqual({
+            status: 'defaulted',
+            reason: 'missing',
+            preferences: createDefaultSimulatorPreferences(),
+        })
+    })
+
+    test('loads valid versioned preferences', () => {
+        const preferences = {
+            ...createDefaultSimulatorPreferences(),
+            presentation: {
+                view: 'ink' as const,
+                outputAudioEnabled: false,
+                keyboardAudioEnabled: false,
+            },
+            simulationMode: 'physical-fidelity' as const,
+        }
+
+        const result = loadSimulatorPreferences({
+            read: () => JSON.stringify(preferences),
+            write: () => undefined,
+        })
+
+        expect(result).toEqual({ status: 'loaded', preferences })
+    })
+
+    test('migrates the legacy presentation choices explicitly', () => {
+        const result = loadSimulatorPreferences({
+            read: () =>
+                JSON.stringify({
+                    version: 0,
+                    showBraille: false,
+                    outputMuted: true,
+                    keyboardMuted: false,
+                }),
+            write: () => undefined,
+        })
+
+        expect(result.status).toBe('migrated')
+        expect(result.preferences).toEqual({
+            ...createDefaultSimulatorPreferences(),
+            presentation: {
+                view: 'ink',
+                outputAudioEnabled: false,
+                keyboardAudioEnabled: true,
+            },
+        })
+    })
+
+    test('falls back explicitly when persisted data is invalid or unavailable', () => {
+        const invalid = loadSimulatorPreferences({
+            read: () => '{invalid-json',
+            write: () => undefined,
+        })
+        const unavailable = loadSimulatorPreferences({
+            read: () => {
+                throw new Error('storage denied')
+            },
+            write: () => undefined,
+        })
+
+        expect(invalid).toEqual({
+            status: 'defaulted',
+            reason: 'invalid',
+            preferences: createDefaultSimulatorPreferences(),
+        })
+        expect(unavailable).toEqual({
+            status: 'defaulted',
+            reason: 'unavailable',
+            preferences: createDefaultSimulatorPreferences(),
+        })
+    })
+
+    test('persists a validated snapshot through the storage seam', () => {
+        const writes: string[] = []
+        const preferences = createDefaultSimulatorPreferences()
+
+        const result = saveSimulatorPreferences(
+            {
+                read: () => null,
+                write: (serialized) => writes.push(serialized),
+            },
+            preferences,
+        )
+
+        expect(result).toEqual({ status: 'saved' })
+        expect(writes).toEqual([JSON.stringify(preferences)])
+    })
+
+    test('applies experience requirements without changing permanent choices', () => {
+        const preferences = {
+            ...createDefaultSimulatorPreferences(),
+            simulationMode: 'physical-fidelity' as const,
+        }
+
+        const result = resolveEffectiveSessionConfiguration(preferences, {
+            interruptionPolicy: 'discard',
+        })
+
+        expect(result).toEqual({
+            configuration: { interruptionPolicy: 'discard' },
+            overriddenPreferences: ['interruptionPolicy'],
+        })
+        expect(preferences.simulationMode).toBe('physical-fidelity')
+        expect(resolveEffectiveSessionConfiguration(preferences, {})).toEqual({
+            configuration: { interruptionPolicy: 'confirm' },
+            overriddenPreferences: [],
+        })
+    })
+
+    test('updates one permanent choice while preserving the remaining snapshot', () => {
+        const initial = createDefaultSimulatorPreferences()
+
+        const updated = applySimulatorPreferenceChange(initial, {
+            type: 'set-view',
+            view: 'ink',
+        })
+
+        expect(updated).toEqual({
+            ...initial,
+            presentation: { ...initial.presentation, view: 'ink' },
+        })
+        expect(initial.presentation.view).toBe('braille')
+    })
+
+    test('updates persistent audio choices independently', () => {
+        const initial = createDefaultSimulatorPreferences()
+        const withoutOutputAudio = applySimulatorPreferenceChange(initial, {
+            type: 'set-output-audio',
+            enabled: false,
+        })
+        const silent = applySimulatorPreferenceChange(withoutOutputAudio, {
+            type: 'set-keyboard-audio',
+            enabled: false,
+        })
+
+        expect(silent.presentation).toEqual({
+            view: 'braille',
+            outputAudioEnabled: false,
+            keyboardAudioEnabled: false,
+        })
+    })
+})

--- a/src/preferences/preferences.test.ts
+++ b/src/preferences/preferences.test.ts
@@ -42,6 +42,7 @@ describe('Simulator preferences', () => {
     })
 
     test('migrates the legacy presentation choices explicitly', () => {
+        const writes: string[] = []
         const result = loadSimulatorPreferences({
             read: () =>
                 JSON.stringify({
@@ -50,10 +51,12 @@ describe('Simulator preferences', () => {
                     outputMuted: true,
                     keyboardMuted: false,
                 }),
-            write: () => undefined,
+            write: (serialized) => writes.push(serialized),
         })
 
         expect(result.status).toBe('migrated')
+        if (result.status !== 'migrated') throw new Error('migration expected')
+        expect(result.migrationPersistence).toBe('saved')
         expect(result.preferences).toEqual({
             ...createDefaultSimulatorPreferences(),
             presentation: {
@@ -62,6 +65,27 @@ describe('Simulator preferences', () => {
                 keyboardAudioEnabled: true,
             },
         })
+        expect(writes).toEqual([JSON.stringify(result.preferences)])
+    })
+
+    test('keeps migrated choices when persisting the new schema fails', () => {
+        const result = loadSimulatorPreferences({
+            read: () =>
+                JSON.stringify({
+                    version: 0,
+                    showBraille: false,
+                    outputMuted: false,
+                    keyboardMuted: false,
+                }),
+            write: () => {
+                throw new Error('storage denied')
+            },
+        })
+
+        expect(result.status).toBe('migrated')
+        if (result.status !== 'migrated') throw new Error('migration expected')
+        expect(result.migrationPersistence).toBe('failed')
+        expect(result.preferences.presentation.view).toBe('ink')
     })
 
     test('falls back explicitly when persisted data is invalid or unavailable', () => {

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -1,0 +1,290 @@
+/** Version of the persisted simulator-preferences schema. */
+export const simulatorPreferencesVersion = 1 as const
+
+/** Physical keyboard codes selected for each configurable simulator action. */
+export type KeyboardBindingPreferences = Readonly<{
+    dot1: string
+    dot2: string
+    dot3: string
+    dot4: string
+    dot5: string
+    dot6: string
+    space: string
+    backspace: string
+    lineChange: string
+    reviewUp: string
+    reviewRight: string
+    reviewDown: string
+    reviewLeft: string
+    toggleCapture: string
+}>
+
+/** Valid choices that persist between typing sessions. */
+export type SimulatorPreferences = Readonly<{
+    version: typeof simulatorPreferencesVersion
+    presentation: Readonly<{
+        view: 'braille' | 'ink'
+        outputAudioEnabled: boolean
+        keyboardAudioEnabled: boolean
+    }>
+    keyboardBindings: KeyboardBindingPreferences
+    simulationMode: 'assisted' | 'physical-fidelity'
+}>
+
+/** Minimal persistence seam implemented by web and deterministic adapters. */
+export type PreferencesStorage = Readonly<{
+    read: () => string | null
+    write: (serialized: string) => void
+}>
+
+/** Observable outcome of loading persisted preferences. */
+export type PreferencesLoadResult = Readonly<{
+    preferences: SimulatorPreferences
+    status: 'loaded' | 'migrated' | 'defaulted'
+    reason?: 'missing' | 'invalid' | 'unavailable'
+}>
+
+/** Observable outcome of attempting to persist preferences. */
+export type PreferencesSaveResult = Readonly<{
+    status: 'saved' | 'failed'
+}>
+
+/** Temporary policies imposed by the active simulator experience. */
+export type ExperienceRequirements = Readonly<{
+    interruptionPolicy?: 'discard' | 'confirm'
+}>
+
+/** Effective policies and the permanent choices they temporarily replace. */
+export type EffectiveSessionConfigurationResult = Readonly<{
+    configuration: Readonly<{
+        interruptionPolicy: 'discard' | 'confirm'
+    }>
+    overriddenPreferences: readonly ['interruptionPolicy'] | readonly []
+}>
+
+/** A validated change to one permanent simulator preference. */
+export type SimulatorPreferenceChange =
+    | Readonly<{
+          type: 'set-view'
+          view: 'braille' | 'ink'
+      }>
+    | Readonly<{
+          type: 'set-output-audio' | 'set-keyboard-audio'
+          enabled: boolean
+      }>
+
+const defaultKeyboardBindings = (): KeyboardBindingPreferences =>
+    Object.freeze({
+        dot1: 'KeyF',
+        dot2: 'KeyD',
+        dot3: 'KeyS',
+        dot4: 'KeyJ',
+        dot5: 'KeyK',
+        dot6: 'KeyL',
+        space: 'Space',
+        backspace: 'Backspace',
+        lineChange: 'KeyQ',
+        reviewUp: 'ArrowUp',
+        reviewRight: 'ArrowRight',
+        reviewDown: 'ArrowDown',
+        reviewLeft: 'ArrowLeft',
+        toggleCapture: 'Escape',
+    })
+
+const keyboardBindingNames = [
+    'dot1',
+    'dot2',
+    'dot3',
+    'dot4',
+    'dot5',
+    'dot6',
+    'space',
+    'backspace',
+    'lineChange',
+    'reviewUp',
+    'reviewRight',
+    'reviewDown',
+    'reviewLeft',
+    'toggleCapture',
+] as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const decodeCurrentPreferences = (
+    value: unknown,
+): SimulatorPreferences | undefined => {
+    if (!isRecord(value) || value.version !== simulatorPreferencesVersion)
+        return undefined
+    if (!isRecord(value.presentation) || !isRecord(value.keyboardBindings))
+        return undefined
+
+    const keyboardBindings = value.keyboardBindings
+    const { view, outputAudioEnabled, keyboardAudioEnabled } =
+        value.presentation
+    if (
+        (view !== 'braille' && view !== 'ink') ||
+        typeof outputAudioEnabled !== 'boolean' ||
+        typeof keyboardAudioEnabled !== 'boolean' ||
+        (value.simulationMode !== 'assisted' &&
+            value.simulationMode !== 'physical-fidelity')
+    ) {
+        return undefined
+    }
+
+    const bindings = Object.fromEntries(
+        keyboardBindingNames.map((name) => [name, keyboardBindings[name]]),
+    )
+    const codes = Object.values(bindings)
+    if (
+        codes.some((code) => typeof code !== 'string' || code.length === 0) ||
+        new Set(codes).size !== codes.length
+    ) {
+        return undefined
+    }
+
+    return Object.freeze({
+        version: simulatorPreferencesVersion,
+        presentation: Object.freeze({
+            view,
+            outputAudioEnabled,
+            keyboardAudioEnabled,
+        }),
+        keyboardBindings: Object.freeze(
+            bindings as unknown as KeyboardBindingPreferences,
+        ),
+        simulationMode: value.simulationMode,
+    })
+}
+
+const migrateLegacyPreferences = (
+    value: unknown,
+): SimulatorPreferences | undefined => {
+    if (
+        !isRecord(value) ||
+        value.version !== 0 ||
+        typeof value.showBraille !== 'boolean' ||
+        typeof value.outputMuted !== 'boolean' ||
+        typeof value.keyboardMuted !== 'boolean'
+    ) {
+        return undefined
+    }
+    const defaults = createDefaultSimulatorPreferences()
+    return Object.freeze({
+        ...defaults,
+        presentation: Object.freeze({
+            view: value.showBraille ? 'braille' : 'ink',
+            outputAudioEnabled: !value.outputMuted,
+            keyboardAudioEnabled: !value.keyboardMuted,
+        }),
+    })
+}
+
+/** Creates the valid defaults used when persistence cannot supply preferences. */
+export const createDefaultSimulatorPreferences = (): SimulatorPreferences =>
+    Object.freeze({
+        version: simulatorPreferencesVersion,
+        presentation: Object.freeze({
+            view: 'braille',
+            outputAudioEnabled: true,
+            keyboardAudioEnabled: true,
+        }),
+        keyboardBindings: defaultKeyboardBindings(),
+        simulationMode: 'assisted',
+    })
+
+/** Loads preferences without allowing storage failures to escape the seam. */
+export const loadSimulatorPreferences = (
+    storage: PreferencesStorage,
+): PreferencesLoadResult => {
+    let serialized: string | null
+    try {
+        serialized = storage.read()
+    } catch {
+        return Object.freeze({
+            preferences: createDefaultSimulatorPreferences(),
+            status: 'defaulted',
+            reason: 'unavailable',
+        })
+    }
+    if (serialized === null) {
+        return Object.freeze({
+            preferences: createDefaultSimulatorPreferences(),
+            status: 'defaulted',
+            reason: 'missing',
+        })
+    }
+    try {
+        const value: unknown = JSON.parse(serialized)
+        const preferences = decodeCurrentPreferences(value)
+        if (preferences !== undefined) {
+            return Object.freeze({ preferences, status: 'loaded' })
+        }
+        const migrated = migrateLegacyPreferences(value)
+        if (migrated !== undefined) {
+            return Object.freeze({ preferences: migrated, status: 'migrated' })
+        }
+    } catch {
+        // Invalid persisted data falls through to the explicit safe default.
+    }
+    return Object.freeze({
+        preferences: createDefaultSimulatorPreferences(),
+        status: 'defaulted',
+        reason: 'invalid',
+    })
+}
+
+/** Persists one valid snapshot without allowing adapter failures to escape. */
+export const saveSimulatorPreferences = (
+    storage: PreferencesStorage,
+    preferences: SimulatorPreferences,
+): PreferencesSaveResult => {
+    try {
+        storage.write(JSON.stringify(preferences))
+        return Object.freeze({ status: 'saved' })
+    } catch {
+        return Object.freeze({ status: 'failed' })
+    }
+}
+
+/** Combines permanent preferences with temporary experience requirements. */
+export const resolveEffectiveSessionConfiguration = (
+    preferences: SimulatorPreferences,
+    requirements: ExperienceRequirements,
+): EffectiveSessionConfigurationResult => {
+    const preferredPolicy =
+        preferences.simulationMode === 'physical-fidelity'
+            ? 'confirm'
+            : 'discard'
+    const overridden = requirements.interruptionPolicy !== undefined
+    return Object.freeze({
+        configuration: Object.freeze({
+            interruptionPolicy:
+                requirements.interruptionPolicy ?? preferredPolicy,
+        }),
+        overriddenPreferences: Object.freeze(
+            overridden ? ['interruptionPolicy'] : [],
+        ) as readonly ['interruptionPolicy'] | readonly [],
+    })
+}
+
+/** Applies one validated preference change without mutating the prior snapshot. */
+export const applySimulatorPreferenceChange = (
+    preferences: SimulatorPreferences,
+    change: SimulatorPreferenceChange,
+): SimulatorPreferences => {
+    const presentation = {
+        ...preferences.presentation,
+        ...(change.type === 'set-view' ? { view: change.view } : {}),
+        ...(change.type === 'set-output-audio'
+            ? { outputAudioEnabled: change.enabled }
+            : {}),
+        ...(change.type === 'set-keyboard-audio'
+            ? { keyboardAudioEnabled: change.enabled }
+            : {}),
+    }
+    return Object.freeze({
+        ...preferences,
+        presentation: Object.freeze(presentation),
+    })
+}

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -1,7 +1,13 @@
 /** Version of the persisted simulator-preferences schema. */
 export const simulatorPreferencesVersion = 1 as const
 
-/** Physical keyboard codes selected for each configurable simulator action. */
+/**
+ * Physical keyboard codes selected for each configurable simulator action.
+ *
+ * Every code is non-empty and unique within the snapshot so one physical key
+ * cannot ambiguously select multiple actions. Persisted snapshots that violate
+ * either invariant are rejected and replaced by explicit defaults on load.
+ */
 export type KeyboardBindingPreferences = Readonly<{
     dot1: string
     dot2: string
@@ -38,11 +44,21 @@ export type PreferencesStorage = Readonly<{
 }>
 
 /** Observable outcome of loading persisted preferences. */
-export type PreferencesLoadResult = Readonly<{
-    preferences: SimulatorPreferences
-    status: 'loaded' | 'migrated' | 'defaulted'
-    reason?: 'missing' | 'invalid' | 'unavailable'
-}>
+export type PreferencesLoadResult =
+    | Readonly<{
+          preferences: SimulatorPreferences
+          status: 'loaded'
+      }>
+    | Readonly<{
+          preferences: SimulatorPreferences
+          status: 'migrated'
+          migrationPersistence: 'saved' | 'failed'
+      }>
+    | Readonly<{
+          preferences: SimulatorPreferences
+          status: 'defaulted'
+          reason: 'missing' | 'invalid' | 'unavailable'
+      }>
 
 /** Observable outcome of attempting to persist preferences. */
 export type PreferencesSaveResult = Readonly<{
@@ -193,7 +209,13 @@ export const createDefaultSimulatorPreferences = (): SimulatorPreferences =>
         simulationMode: 'assisted',
     })
 
-/** Loads preferences without allowing storage failures to escape the seam. */
+/**
+ * Loads preferences without allowing storage failures to escape the seam.
+ *
+ * Missing, invalid, or unavailable data produces valid defaults with an
+ * explicit reason. A migrated payload is written back immediately; failure to
+ * write it remains observable without discarding the migrated choices.
+ */
 export const loadSimulatorPreferences = (
     storage: PreferencesStorage,
 ): PreferencesLoadResult => {
@@ -222,7 +244,17 @@ export const loadSimulatorPreferences = (
         }
         const migrated = migrateLegacyPreferences(value)
         if (migrated !== undefined) {
-            return Object.freeze({ preferences: migrated, status: 'migrated' })
+            let migrationPersistence: 'saved' | 'failed' = 'saved'
+            try {
+                storage.write(JSON.stringify(migrated))
+            } catch {
+                migrationPersistence = 'failed'
+            }
+            return Object.freeze({
+                preferences: migrated,
+                status: 'migrated',
+                migrationPersistence,
+            })
         }
     } catch {
         // Invalid persisted data falls through to the explicit safe default.

--- a/src/preferences/public.ts
+++ b/src/preferences/public.ts
@@ -1,0 +1,22 @@
+export {
+    applySimulatorPreferenceChange,
+    createDefaultSimulatorPreferences,
+    loadSimulatorPreferences,
+    resolveEffectiveSessionConfiguration,
+    saveSimulatorPreferences,
+    simulatorPreferencesVersion,
+    type KeyboardBindingPreferences,
+    type EffectiveSessionConfigurationResult,
+    type ExperienceRequirements,
+    type PreferencesLoadResult,
+    type PreferencesSaveResult,
+    type PreferencesStorage,
+    type SimulatorPreferences,
+    type SimulatorPreferenceChange,
+} from './preferences'
+export { createMemoryPreferencesStorage } from './adapters/memory/memory'
+export {
+    createLocalStoragePreferencesStorage,
+    simulatorPreferencesStorageKey,
+    type WebStorage,
+} from './adapters/web/local-storage/localStorage'

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -7,6 +7,10 @@ Configuração efetiva da sessão e interpretação observável. Seu núcleo é 
 recebe `SessionInput`, devolve novo estado, snapshot e fatos semânticos e não
 depende de React, DOM, áudio ou dispositivo.
 
+A Configuração efetiva é resolvida pela capacidade `preferences` antes da
+criação da sessão. A sessão recebe somente o resultado imutável e nunca persiste
+nem altera Preferências do simulador.
+
 O Documento Braille contido em `TypingSessionState` é a única fonte de verdade
 da produção. A Interpretação Braille existe somente como projeção derivada em
 `TypingSessionSnapshot`.

--- a/src/session/adapters/web/keyboard/keyboard.test.ts
+++ b/src/session/adapters/web/keyboard/keyboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import {
     createDefaultWebKeyboardBindings,
+    createWebKeyboardBindings,
     mapWebKeyboardEvent,
 } from '../../../public'
 
@@ -137,6 +138,42 @@ describe('Web keyboard adapter', () => {
                     control: { type: 'dot', dot: 1 },
                 },
             ],
+        })
+    })
+
+    test('builds adapter bindings from persisted keyboard preferences', () => {
+        const bindings = createWebKeyboardBindings({
+            dot1: 'KeyA',
+            dot2: 'KeyD',
+            dot3: 'KeyS',
+            dot4: 'KeyJ',
+            dot5: 'KeyK',
+            dot6: 'KeyL',
+            space: 'Space',
+            backspace: 'Backspace',
+            lineChange: 'KeyQ',
+            reviewUp: 'ArrowUp',
+            reviewRight: 'ArrowRight',
+            reviewDown: 'ArrowDown',
+            reviewLeft: 'ArrowLeft',
+            toggleCapture: 'Escape',
+        })
+
+        expect(
+            mapWebKeyboardEvent(
+                {
+                    code: 'KeyA',
+                    repeat: false,
+                    ctrlKey: false,
+                    altKey: false,
+                    metaKey: false,
+                },
+                'press',
+                bindings,
+            ),
+        ).toMatchObject({
+            handled: true,
+            control: { type: 'dot', dot: 1 },
         })
     })
 })

--- a/src/session/adapters/web/keyboard/keyboard.ts
+++ b/src/session/adapters/web/keyboard/keyboard.ts
@@ -4,6 +4,10 @@ import {
     type MachineIntent,
     type ReviewDirection,
 } from '../../../../braille/public'
+import {
+    createDefaultSimulatorPreferences,
+    type KeyboardBindingPreferences,
+} from '../../../../preferences/public'
 
 /** Browser keyboard data required by the web adapter. */
 export type WebKeyboardEvent = Readonly<{
@@ -37,52 +41,68 @@ export type WebKeyboardBindings = ReadonlyMap<
     | Readonly<{ command: WebKeyboardCommand }>
 >
 
-const dotByCode = new Map<string, number>([
-    ['KeyF', 1],
-    ['KeyD', 2],
-    ['KeyS', 3],
-    ['KeyJ', 4],
-    ['KeyK', 5],
-    ['KeyL', 6],
-])
-
-const directControlsByCode = new Map<string, readonly MachineControl[]>([
-    ['Space', [Object.freeze({ type: 'space' })]],
-    ['Backspace', [Object.freeze({ type: 'backspace' })]],
-    [
-        'KeyQ',
-        [
-            Object.freeze({ type: 'line-feed' }),
-            Object.freeze({ type: 'carriage-return' }),
-        ],
-    ],
-])
-
-const reviewDirectionByCode = new Map<string, ReviewDirection>([
-    ['ArrowUp', 'up'],
-    ['ArrowRight', 'right'],
-    ['ArrowDown', 'down'],
-    ['ArrowLeft', 'left'],
-])
-
-const controlsForCode = (code: string): readonly MachineControl[] => {
-    const dot = dotByCode.get(code)
-    return dot === undefined
-        ? (directControlsByCode.get(code) ?? [])
-        : [Object.freeze({ type: 'dot', dot: createBrailleDot(dot) })]
-}
-
-/** Creates an independent copy of the standard free-mode key bindings. */
-export const createDefaultWebKeyboardBindings = (): WebKeyboardBindings => {
+/** Creates adapter bindings from validated simulator preferences. */
+export const createWebKeyboardBindings = (
+    codes: KeyboardBindingPreferences,
+): WebKeyboardBindings => {
     const bindings = new Map<
         string,
         | Readonly<{ controls: readonly MachineControl[] }>
         | Readonly<{ command: WebKeyboardCommand }>
     >()
-    for (const code of [...dotByCode.keys(), ...directControlsByCode.keys()]) {
-        bindings.set(code, Object.freeze({ controls: controlsForCode(code) }))
-    }
-    for (const [code, direction] of reviewDirectionByCode) {
+    const dots = [
+        codes.dot1,
+        codes.dot2,
+        codes.dot3,
+        codes.dot4,
+        codes.dot5,
+        codes.dot6,
+    ]
+    dots.forEach((code, index) =>
+        bindings.set(
+            code,
+            Object.freeze({
+                controls: Object.freeze([
+                    Object.freeze({
+                        type: 'dot' as const,
+                        dot: createBrailleDot(index + 1),
+                    }),
+                ]),
+            }),
+        ),
+    )
+    bindings.set(
+        codes.space,
+        Object.freeze({
+            controls: Object.freeze([
+                Object.freeze({ type: 'space' as const }),
+            ]),
+        }),
+    )
+    bindings.set(
+        codes.backspace,
+        Object.freeze({
+            controls: Object.freeze([
+                Object.freeze({ type: 'backspace' as const }),
+            ]),
+        }),
+    )
+    bindings.set(
+        codes.lineChange,
+        Object.freeze({
+            controls: Object.freeze([
+                Object.freeze({ type: 'line-feed' as const }),
+                Object.freeze({ type: 'carriage-return' as const }),
+            ]),
+        }),
+    )
+    const reviewCodes: readonly [string, ReviewDirection][] = [
+        [codes.reviewUp, 'up'],
+        [codes.reviewRight, 'right'],
+        [codes.reviewDown, 'down'],
+        [codes.reviewLeft, 'left'],
+    ]
+    reviewCodes.forEach(([code, direction]) =>
         bindings.set(
             code,
             Object.freeze({
@@ -91,16 +111,22 @@ export const createDefaultWebKeyboardBindings = (): WebKeyboardBindings => {
                     direction,
                 }),
             }),
-        )
-    }
+        ),
+    )
     bindings.set(
-        'Escape',
+        codes.toggleCapture,
         Object.freeze({
             command: Object.freeze({ type: 'toggle-capture' as const }),
         }),
     )
     return bindings
 }
+
+/** Creates an independent copy of the standard free-mode key bindings. */
+export const createDefaultWebKeyboardBindings = (): WebKeyboardBindings =>
+    createWebKeyboardBindings(
+        createDefaultSimulatorPreferences().keyboardBindings,
+    )
 
 const defaultBindings = createDefaultWebKeyboardBindings()
 

--- a/src/session/public.ts
+++ b/src/session/public.ts
@@ -15,6 +15,7 @@ export {
 export {
     mapWebKeyboardEvent,
     createDefaultWebKeyboardBindings,
+    createWebKeyboardBindings,
     type WebKeyboardBindings,
     type WebKeyboardEvent,
     type WebKeyboardMapping,

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -5,6 +5,7 @@ import type { MachineControl } from '../../braille/public'
 import Keyboard from '../../components/Keyboard'
 import { Cell, cellToString } from '../../domain/Cell'
 import { Key } from '../../domain/Key'
+import type { SimulatorPreferences } from '../../preferences/public'
 import {
     mapWebKeyboardEvent,
     type SessionInput,
@@ -81,6 +82,7 @@ export type FreeTypingSessionProps = Readonly<{
     snapshot: TypingSessionSnapshot
     dispatch: (input: SessionInput) => void
     keyboardBindings: WebKeyboardBindings
+    presentationPreferences: SimulatorPreferences['presentation']
     onPresentationAction: (action: LegacyFreeModeAction) => void
     onMachineKeyPressed: () => void
 }>
@@ -89,12 +91,10 @@ export default function FreeTypingSession({
     snapshot,
     dispatch,
     keyboardBindings,
+    presentationPreferences,
     onPresentationAction,
     onMachineKeyPressed,
 }: FreeTypingSessionProps) {
-    const [showBraille, setShowBraille] = useState(true)
-    const [, setOutputMuted] = useState(false)
-    const [keyboardMuted, setKeyboardMuted] = useState(false)
     const [keyStatus, setKeyStatus] = useState(initialKeyStatus)
 
     const output = useMemo(() => legacyText(snapshot), [snapshot])
@@ -135,11 +135,6 @@ export default function FreeTypingSession({
         const action = legacyFreeModeActionForKey(event)
         if (action === undefined) return false
         event.preventDefault()
-        if (action === 'view-toggled') setShowBraille((current) => !current)
-        if (action === 'output-audio-toggled')
-            setOutputMuted((current) => !current)
-        if (action === 'keyboard-audio-toggled')
-            setKeyboardMuted((current) => !current)
         onPresentationAction(action)
         return true
     }
@@ -161,7 +156,11 @@ export default function FreeTypingSession({
                 [visualKey]: type === 'press',
             }))
         }
-        if (type === 'press' && !event.repeat && !keyboardMuted)
+        if (
+            type === 'press' &&
+            !event.repeat &&
+            presentationPreferences.keyboardAudioEnabled
+        )
             onMachineKeyPressed()
 
         if (mapping.command?.type === 'move-review') {
@@ -219,7 +218,7 @@ export default function FreeTypingSession({
             </div>
             <textarea
                 aria-label="Saída de Celas Braille digitadas"
-                className={`form-control p-5 mb-3 ${showBraille ? 'braille' : ''}`}
+                className={`form-control p-5 mb-3 ${presentationPreferences.view === 'braille' ? 'braille' : ''}`}
                 readOnly
                 rows={3}
                 value={output}

--- a/src/views/modes/Free.tsx
+++ b/src/views/modes/Free.tsx
@@ -9,27 +9,59 @@ import {
 } from '../../braille/public'
 import {
     applySessionInput,
-    createDefaultWebKeyboardBindings,
+    createWebKeyboardBindings,
     createTypingSession,
     getTypingSessionSnapshot,
     type SessionInput,
 } from '../../session/public'
 import { FreeTypingSession, type LegacyFreeModeAction } from '../../ui/public'
+import {
+    applySimulatorPreferenceChange,
+    createLocalStoragePreferencesStorage,
+    loadSimulatorPreferences,
+    resolveEffectiveSessionConfiguration,
+    saveSimulatorPreferences,
+    type SimulatorPreferenceChange,
+    type SimulatorPreferences,
+} from '../../preferences/public'
 
-const createFreeSession = () =>
+const freeModeRequirements = Object.freeze({})
+
+const createFreeSession = (preferences: SimulatorPreferences) =>
     createTypingSession({
         paper: createPaperConfiguration({
             type: 'continuous',
             columns: 40,
         }),
         profile: createOrthographyProfile('portuguese-braille-2018'),
-        effectiveConfiguration: { interruptionPolicy: 'discard' },
+        effectiveConfiguration: resolveEffectiveSessionConfiguration(
+            preferences,
+            freeModeRequirements,
+        ).configuration,
     })
 
 export default function Free() {
-    const [session, setSession] = useState(createFreeSession)
+    const preferencesStorage = useMemo(createLocalStoragePreferencesStorage, [])
+    const [initialPreferences] = useState(() =>
+        loadSimulatorPreferences(preferencesStorage),
+    )
+    const [preferences, setPreferences] = useState(
+        initialPreferences.preferences,
+    )
+    const [preferencesNotice, setPreferencesNotice] = useState(() =>
+        initialPreferences.reason === 'invalid' ||
+        initialPreferences.reason === 'unavailable'
+            ? 'As preferências salvas não puderam ser carregadas; os padrões foram aplicados.'
+            : undefined,
+    )
+    const [session, setSession] = useState(() =>
+        createFreeSession(initialPreferences.preferences),
+    )
     const snapshot = useMemo(() => getTypingSessionSnapshot(session), [session])
-    const keyboardBindings = useMemo(createDefaultWebKeyboardBindings, [])
+    const keyboardBindings = useMemo(
+        () => createWebKeyboardBindings(preferences.keyboardBindings),
+        [preferences.keyboardBindings],
+    )
     const {
         playHowToAccessInstructionsAudio,
         playFreeModeInstructionsAudio,
@@ -41,9 +73,6 @@ export default function Free() {
         playBrailleViewAudio,
         playInkViewAudio,
     } = useAudioContext()
-    const [showingBraille, setShowingBraille] = useState(true)
-    const [outputMuted, setOutputMuted] = useState(false)
-    const [keyboardMuted, setKeyboardMuted] = useState(false)
 
     useEffect(() => {
         playHowToAccessInstructionsAudio(() => {})
@@ -57,20 +86,41 @@ export default function Free() {
         (action: LegacyFreeModeAction) => {
             if (action === 'instructions-requested') {
                 playFreeModeInstructionsAudio()
-            } else if (action === 'view-toggled') {
-                showingBraille ? playInkViewAudio() : playBrailleViewAudio()
-                setShowingBraille((current) => !current)
-            } else if (action === 'output-audio-toggled') {
-                outputMuted ? playOutputUnmuted() : playOutputMuted()
-                setOutputMuted((current) => !current)
-            } else {
-                keyboardMuted ? playKeyboardUnmuted() : playKeyboardMuted()
-                setKeyboardMuted((current) => !current)
+                return
             }
+
+            let change: SimulatorPreferenceChange
+            if (action === 'view-toggled') {
+                const showingBraille =
+                    preferences.presentation.view === 'braille'
+                showingBraille ? playInkViewAudio() : playBrailleViewAudio()
+                change = {
+                    type: 'set-view',
+                    view: showingBraille ? 'ink' : 'braille',
+                }
+            } else if (action === 'output-audio-toggled') {
+                const enabled = preferences.presentation.outputAudioEnabled
+                enabled ? playOutputMuted() : playOutputUnmuted()
+                change = { type: 'set-output-audio', enabled: !enabled }
+            } else {
+                const enabled = preferences.presentation.keyboardAudioEnabled
+                enabled ? playKeyboardMuted() : playKeyboardUnmuted()
+                change = { type: 'set-keyboard-audio', enabled: !enabled }
+            }
+
+            const updated = applySimulatorPreferenceChange(preferences, change)
+            setPreferences(updated)
+            const saveResult = saveSimulatorPreferences(
+                preferencesStorage,
+                updated,
+            )
+            setPreferencesNotice(
+                saveResult.status === 'failed'
+                    ? 'A preferência foi aplicada nesta sessão, mas não pôde ser salva.'
+                    : undefined,
+            )
         },
         [
-            keyboardMuted,
-            outputMuted,
             playBrailleViewAudio,
             playFreeModeInstructionsAudio,
             playInkViewAudio,
@@ -78,17 +128,22 @@ export default function Free() {
             playKeyboardUnmuted,
             playOutputMuted,
             playOutputUnmuted,
-            showingBraille,
+            preferences,
+            preferencesStorage,
         ],
     )
 
     return (
         <>
             <main>
+                {preferencesNotice !== undefined && (
+                    <div role="alert">{preferencesNotice}</div>
+                )}
                 <FreeTypingSession
                     snapshot={snapshot}
                     dispatch={dispatch}
                     keyboardBindings={keyboardBindings}
+                    presentationPreferences={preferences.presentation}
                     onPresentationAction={handlePresentationAction}
                     onMachineKeyPressed={playKeyPress}
                 />

--- a/tests/contracts/preferences-storage.test.ts
+++ b/tests/contracts/preferences-storage.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+    createDefaultSimulatorPreferences,
+    createLocalStoragePreferencesStorage,
+    createMemoryPreferencesStorage,
+    loadSimulatorPreferences,
+    saveSimulatorPreferences,
+    type PreferencesStorage,
+} from '../../src/preferences/public'
+
+type StorageFactory = () => PreferencesStorage
+
+const createWebStorage = (): StorageFactory => {
+    const values = new Map<string, string>()
+    return () =>
+        createLocalStoragePreferencesStorage({
+            getItem: (key) => values.get(key) ?? null,
+            setItem: (key, value) => values.set(key, value),
+        })
+}
+
+describe.each<[string, StorageFactory]>([
+    ['memory adapter', () => createMemoryPreferencesStorage()],
+    ['web local-storage adapter', createWebStorage()],
+])('%s', (_name, createStorage) => {
+    test('satisfies the simulator-preferences storage seam', () => {
+        const storage = createStorage()
+        const preferences = {
+            ...createDefaultSimulatorPreferences(),
+            presentation: {
+                view: 'ink' as const,
+                outputAudioEnabled: false,
+                keyboardAudioEnabled: true,
+            },
+        }
+
+        expect(loadSimulatorPreferences(storage).status).toBe('defaulted')
+        expect(saveSimulatorPreferences(storage, preferences)).toEqual({
+            status: 'saved',
+        })
+        expect(loadSimulatorPreferences(storage)).toEqual({
+            status: 'loaded',
+            preferences,
+        })
+    })
+})

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -8,7 +8,7 @@ import {
     createDefaultSimulatorPreferences,
     simulatorPreferencesStorageKey,
 } from '../../src/preferences/public'
-import Free from '../../src/views/modes/Free'
+import { FreePage } from '../../src/app/public'
 
 class AudioStub {
     static instances: AudioStub[] = []
@@ -27,7 +27,7 @@ const renderFreeMode = () =>
     render(
         <AudioProvider>
             <MemoryRouter>
-                <Free />
+                <FreePage />
             </MemoryRouter>
         </AudioProvider>,
     )
@@ -115,7 +115,7 @@ test('Modo livre interrompe acorde incompleto e permite pausar a captura', () =>
     expect(captureStatus).toHaveTextContent('Captura ativa')
 })
 
-test('Modo livre preserves presentation preferences between typing sessions', async () => {
+test('Free Mode preserves presentation preferences between typing sessions', async () => {
     const firstSession = renderFreeMode()
     const firstTypewriter = screen.getByRole('region', {
         name: 'Área de digitação Braille',
@@ -149,7 +149,7 @@ test('Modo livre preserves presentation preferences between typing sessions', as
     })
 })
 
-test('Modo livre keeps the current session usable when persistence fails', () => {
+test('Free Mode keeps the current session usable when persistence fails', () => {
     vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
         throw new Error('storage denied')
     })
@@ -169,7 +169,7 @@ test('Modo livre keeps the current session usable when persistence fails', () =>
     )
 })
 
-test('Modo livre uses persisted keyboard bindings in a new session', () => {
+test('Free Mode uses persisted keyboard bindings in a new session', () => {
     const defaults = createDefaultSimulatorPreferences()
     globalThis.localStorage.setItem(
         simulatorPreferencesStorageKey,

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -4,6 +4,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 import AudioProvider from '../../src/providers/AudioProvider'
+import {
+    createDefaultSimulatorPreferences,
+    simulatorPreferencesStorageKey,
+} from '../../src/preferences/public'
 import Free from '../../src/views/modes/Free'
 
 class AudioStub {
@@ -44,6 +48,7 @@ const audioEndingWith = (path: string) =>
 beforeEach(() => {
     AudioStub.instances = []
     globalThis.Audio = AudioStub as unknown as typeof Audio
+    globalThis.localStorage.clear()
 })
 
 afterEach(() => vi.restoreAllMocks())
@@ -108,4 +113,82 @@ test('Modo livre interrompe acorde incompleto e permite pausar a captura', () =>
     expect(captureStatus).toHaveTextContent('Captura inativa')
     press(typewriter, 'Escape')
     expect(captureStatus).toHaveTextContent('Captura ativa')
+})
+
+test('Modo livre preserves presentation preferences between typing sessions', async () => {
+    const firstSession = renderFreeMode()
+    const firstTypewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    fireEvent.focus(firstTypewriter)
+    press(firstTypewriter, 'KeyT')
+    press(firstTypewriter, 'KeyO')
+    press(firstTypewriter, 'KeyM')
+    expect(screen.getByRole('textbox')).not.toHaveClass('braille')
+
+    firstSession.unmount()
+    AudioStub.instances = []
+    renderFreeMode()
+    const secondTypewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    expect(screen.getByRole('textbox')).not.toHaveClass('braille')
+    fireEvent.focus(secondTypewriter)
+    press(secondTypewriter, 'KeyO')
+    press(secondTypewriter, 'KeyM')
+
+    await waitFor(() => {
+        expect(
+            audioEndingWith('conversor-desmutado.mp3')?.play,
+        ).toHaveBeenCalled()
+        expect(
+            audioEndingWith('teclado-desmutado.mp3')?.play,
+        ).toHaveBeenCalled()
+    })
+})
+
+test('Modo livre keeps the current session usable when persistence fails', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage denied')
+    })
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    fireEvent.focus(typewriter)
+    press(typewriter, 'KeyT')
+    press(typewriter, 'KeyF')
+
+    expect(screen.getByRole('textbox')).not.toHaveClass('braille')
+    expect(screen.getByRole('textbox')).toHaveValue('a')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+        'A preferência foi aplicada nesta sessão, mas não pôde ser salva.',
+    )
+})
+
+test('Modo livre uses persisted keyboard bindings in a new session', () => {
+    const defaults = createDefaultSimulatorPreferences()
+    globalThis.localStorage.setItem(
+        simulatorPreferencesStorageKey,
+        JSON.stringify({
+            ...defaults,
+            keyboardBindings: {
+                ...defaults.keyboardBindings,
+                dot1: 'KeyA',
+            },
+        }),
+    )
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    fireEvent.focus(typewriter)
+    press(typewriter, 'KeyF')
+    expect(screen.getByRole('textbox')).toHaveValue('')
+    press(typewriter, 'KeyA')
+    expect(screen.getByRole('textbox')).toHaveValue('a')
 })


### PR DESCRIPTION
## Resumo

- adiciona Preferências do simulador versionadas, validadas e migráveis
- persiste escolhas do Modo livre por adapters web e de memória
- aplica requisitos temporários somente à configuração efetiva da sessão
- preserva a sessão corrente diante de falhas de armazenamento
- integra preferências de apresentação, áudio e bindings ao Modo livre
- documenta o contrato e atualiza o changelog

## Validação

- npm run ci
- 84 testes Vitest e 30 testes de políticas
- typecheck, arquitetura, lint, build e auditoria aprovados

Closes #42