### PR TITLE
feat(feedback): conclui fala e sons substituíveis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
   com migração explícita, fallback seguro e adapters web e determinístico.
 - Planejador puro de Feedback multimodal com mensagens visuais e programáticas
   equivalentes no Modo livre e saídas determinísticas isoladas contra falhas.
+- Leitura falada por Web Speech e sons opcionais substituíveis no Modo livre,
+  com preferências portáveis, interrupção, repetição e fallback sem áudio.
 
 ## [3.0.0-alpha.1] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Todas as mudanças relevantes deste projeto serão registradas neste arquivo. As
 - Leitura falada por Web Speech e sons opcionais substituíveis no Modo livre,
   com preferências portáveis, interrupção, repetição e fallback sem áudio.
 
+### Fixed
+
+- Conteúdo falado do menu, das instruções e das palavras do desafio usa síntese
+  de voz sem sobrepor gravações; os controles do Modo livre continuam ativos
+  após perda de foco, a tecla O controla a leitura automática dos símbolos e
+  todas as saídas são interrompidas ao sair da experiência.
+
 ## [3.0.0-alpha.1] - 2026-09-09
 
 ### Added

--- a/config/lint-baseline.json
+++ b/config/lint-baseline.json
@@ -12,9 +12,6 @@
         "src/components/Typewriter.tsx:react-hooks/exhaustive-deps:React Hook useEffect has missing dependencies: 'isOutputMuted', 'noKeyPressedCurrently', 'outputReference', 'playCellAudio', 'pressedKeys', and 'typedCells'. Either include them or remove the dependency array. You can also do a functional update 'setPressedKeys(p => ...)' if you only need 'pressedKeys' in the 'setPressedKeys' call.",
         "src/tests/Journeys.test.tsx:testing-library/no-container:Avoid using container methods. Prefer using the methods from Testing Library, such as \"getByRole()\"",
         "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
-        "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library.",
-        "src/views/Home.tsx:@typescript-eslint/no-unused-vars:'handleBtnAboutFocused' is defined but never used.",
-        "src/views/Home.tsx:react-hooks/exhaustive-deps:React Hook useEffect has a missing dependency: 'playMainMenuAudio'. Either include it or remove the dependency array.",
-        "src/views/modes/Challenge.tsx:react-hooks/exhaustive-deps:React Hook useEffect has missing dependencies: 'playHowToAccessInstructionsAudio' and 'playRandomWordAudio'. Either include them or remove the dependency array."
+        "src/tests/Journeys.test.tsx:testing-library/no-node-access:Avoid direct Node access. Prefer using the methods from Testing Library."
     ]
 }

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,8 @@ Esta área descreve a arquitetura alvo da modernização. Ela é a fonte canôni
 - [Plano de migração](migration-plan.md): fases, pré-requisitos, versões, auditorias e rollback.
 - [Prontidão da Sessão para Alpha 1](session-alpha-1.md): portões, evidências e
   rollback do corte do Modo livre.
+- [Prontidão de Preferências e Feedback para Alpha 2](feedback-alpha-2.md):
+  portões e evidências das saídas substituíveis no Modo livre.
 - [Baseline operacional](modernization-baseline.md): marcos recuperáveis, jornadas essenciais, inventário legado e estratégia de rollback.
 - [Corte do build Vite](vite-build-baseline.md): comandos canônicos, artifact,
   evidências da coexistência encerrada e rollback do corte de plataforma.

--- a/docs/architecture/feedback-alpha-2.md
+++ b/docs/architecture/feedback-alpha-2.md
@@ -13,6 +13,8 @@ Este registro documenta os portões técnicos da fase 6 na jornada do Modo livre
   indisponibilidade, cancelamento ou falha das saídas.
 - O Modo livre permite ativar ou silenciar fala e sons, repetir a última fala e
   interromper as saídas sem mover o foco da área de digitação.
+- A letra O ativa ou desativa a leitura automática dos Símbolos textuais
+  produzidos; instruções solicitadas por I permanecem disponíveis separadamente.
 - Um controlador da capacidade `feedback` concentra seleção de canal,
   interrupção, repetição, instruções e tratamento de indisponibilidade; a página
   apenas compõe adapters, encaminha fatos e persiste escolhas.

--- a/docs/architecture/feedback-alpha-2.md
+++ b/docs/architecture/feedback-alpha-2.md
@@ -13,6 +13,9 @@ Este registro documenta os portões técnicos da fase 6 na jornada do Modo livre
   indisponibilidade, cancelamento ou falha das saídas.
 - O Modo livre permite ativar ou silenciar fala e sons, repetir a última fala e
   interromper as saídas sem mover o foco da área de digitação.
+- Um controlador da capacidade `feedback` concentra seleção de canal,
+  interrupção, repetição, instruções e tratamento de indisponibilidade; a página
+  apenas compõe adapters, encaminha fatos e persiste escolhas.
 - Não existe detecção de leitor de tela.
 - O Modo livre não consome o `AudioProvider`; o executor permanece isolado nos
   destinos legados até a substituição de seus últimos consumidores, sem
@@ -25,6 +28,9 @@ Este registro documenta os portões técnicos da fase 6 na jornada do Modo livre
 - testes de preferências cobrem schema v2, migração e persistência;
 - contratos web substituem as APIs reais de fala e som;
 - a jornada cobre fala ligada, repetição, interrupção e conclusão sem áudio;
+- o estado ligado/desligado de fala e sons é textual e anunciado; fala é uma
+  modalidade opcional, ativada explicitamente, enquanto a região viva continua
+  sendo a saída acessível canônica sem qualquer detecção de leitor de tela;
 - `npm run ci` registra o portão automatizado final.
 
 ## Verificação manual para publicação

--- a/docs/architecture/feedback-alpha-2.md
+++ b/docs/architecture/feedback-alpha-2.md
@@ -1,0 +1,43 @@
+# Prontidão de Preferências e Feedback para Alpha 2
+
+Este registro documenta os portões técnicos da fase 6 na jornada do Modo livre.
+
+## Portões
+
+- Preferências usam schema v2 e persistem fala e sons sem identificar uma voz
+  pelo nome bruto fornecido pela plataforma.
+- Web Speech recebe texto canônico, localidade BCP 47, finalidade, preferência
+  lógica, velocidade, pitch e volume, com fallback por idioma-base.
+- Sons recebem identificadores semânticos e resolvem assets dentro do adapter.
+- Texto e semântica acessível permanecem ativos diante de silêncio,
+  indisponibilidade, cancelamento ou falha das saídas.
+- O Modo livre permite ativar ou silenciar fala e sons, repetir a última fala e
+  interromper as saídas sem mover o foco da área de digitação.
+- Não existe detecção de leitor de tela.
+- O Modo livre não consome o `AudioProvider`; o executor permanece isolado nos
+  destinos legados até a substituição de seus últimos consumidores, sem
+  feedback duplicado na jornada modernizada.
+- O CI canônico valida formatação, lint, tipos, arquitetura, testes, build e
+  auditoria.
+
+## Evidências
+
+- testes de preferências cobrem schema v2, migração e persistência;
+- contratos web substituem as APIs reais de fala e som;
+- a jornada cobre fala ligada, repetição, interrupção e conclusão sem áudio;
+- `npm run ci` registra o portão automatizado final.
+
+## Verificação manual para publicação
+
+1. Ativar a fala com O num navegador com voz `pt-BR`.
+2. Repetir com R e interromper com P sem perder o foco.
+3. Desativar fala e sons e concluir produção, revisão e correção.
+4. Repetir sem voz portuguesa e confirmar o aviso textual sem bloqueio.
+5. Avaliar fala ligada e desligada com NVDA/Firefox, NVDA/Chrome e
+   VoiceOver/Safari, observando anúncios duplicados.
+
+## Rollback
+
+Reverter a integração restaura temporariamente o executor anterior no Modo
+livre. Schemas anteriores permanecem migráveis e nenhuma preferência depende de
+uma voz concreta instalada.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
                 "immutable": "^5.0.0-beta.5",
                 "react": "^19.2.8",
                 "react-dom": "^19.2.8",
-                "react-router-dom": "^6.22.3",
-                "use-sound": "^4.0.1"
+                "react-router-dom": "^6.22.3"
             },
             "devDependencies": {
                 "@testing-library/dom": "^10.4.1",
@@ -2183,11 +2182,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/howler": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
-            "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w=="
-        },
         "node_modules/html-encoding-sniffer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -3527,17 +3521,6 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/use-sound": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/use-sound/-/use-sound-4.0.1.tgz",
-            "integrity": "sha512-hykJ86kNcu6y/FzlSHcQxhjSGMslZx2WlfLpZNoPbvueakv4OF3xPxEtGV2YmculrIaH0tPp9LtG4jgy17xMWg==",
-            "dependencies": {
-                "howler": "^2.1.3"
-            },
-            "peerDependencies": {
-                "react": ">=16.8"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
         "immutable": "^5.0.0-beta.5",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^6.22.3",
-        "use-sound": "^4.0.1"
+        "react-router-dom": "^6.22.3"
     },
     "scripts": {
         "start": "vite",

--- a/src/app/pages/FreePage.tsx
+++ b/src/app/pages/FreePage.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 
 import '../../styles/views/modes/Free.css'
 
-import { useAudioContext } from '../../providers/AudioProvider'
 import {
     createOrthographyProfile,
     createPaperConfiguration,
@@ -21,8 +20,12 @@ import {
 } from '../../ui/public'
 import {
     coordinateSessionFeedback,
+    createBrowserSpeechOutput,
     createFeedbackCoordinatorState,
+    createWebSoundOutput,
+    resolveFeedbackMessage,
     type MessageFeedbackPlan,
+    type SpeechRequest,
 } from '../../feedback/public'
 import {
     applySimulatorPreferenceChange,
@@ -57,6 +60,8 @@ export default function FreePage() {
     const [preferences, setPreferences] = useState(
         initialPreferences.preferences,
     )
+    const preferencesRef = useRef(preferences)
+    preferencesRef.current = preferences
     const [preferencesNotice, setPreferencesNotice] = useState(() => {
         if (
             initialPreferences.status === 'migrated' &&
@@ -83,39 +88,76 @@ export default function FreePage() {
         () => createWebKeyboardBindings(preferences.keyboardBindings),
         [preferences.keyboardBindings],
     )
-    const {
-        playHowToAccessInstructionsAudio,
-        playFreeModeInstructionsAudio,
-        playKeyPress,
-        playKeyboardMuted,
-        playKeyboardUnmuted,
-        playOutputMuted,
-        playOutputUnmuted,
-        playBrailleViewAudio,
-        playInkViewAudio,
-    } = useAudioContext()
+    const speechOutput = useMemo(createBrowserSpeechOutput, [])
+    const soundOutput = useMemo(createWebSoundOutput, [])
+    const lastSpeechRequest = useRef<SpeechRequest | undefined>(undefined)
 
-    useEffect(() => {
-        playHowToAccessInstructionsAudio(() => {})
-    }, [])
+    const speak = useCallback(
+        (text: string, purpose: SpeechRequest['purpose']) => {
+            const speech = preferencesRef.current.feedback.speech
+            if (!speech.enabled || speechOutput === undefined) return
+            const { enabled: _enabled, ...speechSettings } = speech
+            const request = Object.freeze({ text, purpose, ...speechSettings })
+            lastSpeechRequest.current = request
+            void speechOutput.speak(request).then((result) => {
+                if (result === 'unavailable' || result === 'failed') {
+                    setPreferencesNotice(
+                        'A leitura falada está indisponível; o texto e as mensagens acessíveis continuam ativos.',
+                    )
+                }
+            })
+        },
+        [speechOutput],
+    )
 
-    const dispatch = useCallback((input: SessionInput) => {
-        const result = applySessionInput(sessionRef.current, input)
-        sessionRef.current = result.state
-        setSession(result.state)
+    const dispatch = useCallback(
+        (input: SessionInput) => {
+            const result = applySessionInput(sessionRef.current, input)
+            sessionRef.current = result.state
+            setSession(result.state)
 
-        const feedback = coordinateSessionFeedback(
-            feedbackCoordinatorRef.current,
-            result.events,
-        )
-        feedbackCoordinatorRef.current = feedback.state
-        if (feedback.plans.length > 0) setFeedbackPlans(feedback.plans)
-    }, [])
+            const feedback = coordinateSessionFeedback(
+                feedbackCoordinatorRef.current,
+                result.events,
+            )
+            feedbackCoordinatorRef.current = feedback.state
+            if (feedback.plans.length > 0) {
+                setFeedbackPlans(feedback.plans)
+                feedback.plans.forEach((plan) => {
+                    if (plan.interruption !== 'none') speechOutput?.cancel()
+                    speak(resolveFeedbackMessage(plan), 'status')
+                })
+            }
+        },
+        [speak, speechOutput],
+    )
 
     const handlePresentationAction = useCallback(
         (action: LegacyFreeModeAction) => {
             if (action === 'instructions-requested') {
-                playFreeModeInstructionsAudio()
+                const instructions =
+                    'Use F, D, S, J, K e L para formar acordes Braille. Use Espaço, Backspace e Q para editar.'
+                if (preferences.feedback.speech.enabled) {
+                    speak(instructions, 'instruction')
+                } else if (preferences.feedback.sounds.enabled) {
+                    void soundOutput.play({
+                        type: 'editorial',
+                        id: 'free-instructions',
+                    })
+                }
+                return
+            }
+            if (action === 'speech-stopped') {
+                speechOutput?.cancel()
+                soundOutput.cancel()
+                return
+            }
+            if (action === 'speech-repeated') {
+                if (
+                    preferences.feedback.speech.enabled &&
+                    lastSpeechRequest.current !== undefined
+                )
+                    void speechOutput?.speak(lastSpeechRequest.current)
                 return
             }
 
@@ -123,19 +165,20 @@ export default function FreePage() {
             if (action === 'view-toggled') {
                 const showingBraille =
                     preferences.presentation.view === 'braille'
-                showingBraille ? playInkViewAudio() : playBrailleViewAudio()
                 change = {
                     type: 'set-view',
                     view: showingBraille ? 'ink' : 'braille',
                 }
             } else if (action === 'output-audio-toggled') {
-                const enabled = preferences.presentation.outputAudioEnabled
-                enabled ? playOutputMuted() : playOutputUnmuted()
-                change = { type: 'set-output-audio', enabled: !enabled }
+                change = {
+                    type: 'set-speech-enabled',
+                    enabled: !preferences.feedback.speech.enabled,
+                }
             } else {
-                const enabled = preferences.presentation.keyboardAudioEnabled
-                enabled ? playKeyboardMuted() : playKeyboardUnmuted()
-                change = { type: 'set-keyboard-audio', enabled: !enabled }
+                change = {
+                    type: 'set-sounds-enabled',
+                    enabled: !preferences.feedback.sounds.enabled,
+                }
             }
 
             const updated = applySimulatorPreferenceChange(preferences, change)
@@ -147,21 +190,28 @@ export default function FreePage() {
             setPreferencesNotice(
                 saveResult.status === 'failed'
                     ? 'A preferência foi aplicada nesta sessão, mas não pôde ser salva.'
-                    : undefined,
+                    : change.type === 'set-speech-enabled' &&
+                        change.enabled &&
+                        speechOutput === undefined
+                      ? 'A leitura falada está indisponível; o texto e as mensagens acessíveis continuam ativos.'
+                      : undefined,
             )
         },
-        [
-            playBrailleViewAudio,
-            playFreeModeInstructionsAudio,
-            playInkViewAudio,
-            playKeyboardMuted,
-            playKeyboardUnmuted,
-            playOutputMuted,
-            playOutputUnmuted,
-            preferences,
-            preferencesStorage,
-        ],
+        [preferences, preferencesStorage, soundOutput, speak, speechOutput],
     )
+
+    const presentationPreferences = useMemo(
+        () => ({
+            ...preferences.presentation,
+            keyboardAudioEnabled: preferences.feedback.sounds.enabled,
+        }),
+        [preferences],
+    )
+
+    const playMachineSound = useCallback(() => {
+        if (preferencesRef.current.feedback.sounds.enabled)
+            void soundOutput.play({ type: 'machine-key' })
+    }, [soundOutput])
 
     return (
         <>
@@ -174,9 +224,9 @@ export default function FreePage() {
                     snapshot={snapshot}
                     dispatch={dispatch}
                     keyboardBindings={keyboardBindings}
-                    presentationPreferences={preferences.presentation}
+                    presentationPreferences={presentationPreferences}
                     onPresentationAction={handlePresentationAction}
-                    onMachineKeyPressed={playKeyPress}
+                    onMachineKeyPressed={playMachineSound}
                 />
             </main>
         </>

--- a/src/app/pages/FreePage.tsx
+++ b/src/app/pages/FreePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import '../../styles/views/modes/Free.css'
 
@@ -16,6 +16,7 @@ import {
 import {
     AccessibleFeedback,
     FreeTypingSession,
+    legacyFreeModeActionForKey,
     type LegacyFreeModeAction,
 } from '../../ui/public'
 import {
@@ -24,6 +25,7 @@ import {
     createFeedbackCoordinatorState,
     createMultimodalFeedbackController,
     createWebSoundOutput,
+    resolveAutomaticReading,
     type MessageFeedbackPlan,
 } from '../../feedback/public'
 import {
@@ -110,6 +112,9 @@ export default function FreePage() {
 
     const dispatch = useCallback(
         (input: SessionInput) => {
+            const previousSnapshot = getTypingSessionSnapshot(
+                sessionRef.current,
+            )
             const result = applySessionInput(sessionRef.current, input)
             sessionRef.current = result.state
             setSession(result.state)
@@ -119,6 +124,13 @@ export default function FreePage() {
                 result.events,
             )
             feedbackCoordinatorRef.current = feedback.state
+            const automaticReading = resolveAutomaticReading(
+                previousSnapshot.interpretation,
+                result.snapshot.interpretation,
+                result.events,
+            )
+            if (automaticReading !== undefined)
+                multimodalFeedback.readProduction(automaticReading)
             if (feedback.plans.length > 0) {
                 setFeedbackPlans(
                     multimodalFeedback.deliverPlans(feedback.plans),
@@ -196,6 +208,25 @@ export default function FreePage() {
     const playMachineSound = useCallback(() => {
         multimodalFeedback.playMachineKey()
     }, [multimodalFeedback])
+
+    useEffect(() => {
+        const handleGlobalPresentationKey = (event: KeyboardEvent) => {
+            if (
+                event.target instanceof Element &&
+                event.target.closest('#typewriter') !== null
+            )
+                return
+            const action = legacyFreeModeActionForKey(event)
+            if (action === undefined) return
+            event.preventDefault()
+            handlePresentationAction(action)
+        }
+        document.addEventListener('keydown', handleGlobalPresentationKey)
+        return () => {
+            document.removeEventListener('keydown', handleGlobalPresentationKey)
+            multimodalFeedback.stop()
+        }
+    }, [handlePresentationAction, multimodalFeedback])
 
     return (
         <>

--- a/src/app/pages/FreePage.tsx
+++ b/src/app/pages/FreePage.tsx
@@ -22,10 +22,9 @@ import {
     coordinateSessionFeedback,
     createBrowserSpeechOutput,
     createFeedbackCoordinatorState,
+    createMultimodalFeedbackController,
     createWebSoundOutput,
-    resolveFeedbackMessage,
     type MessageFeedbackPlan,
-    type SpeechRequest,
 } from '../../feedback/public'
 import {
     applySimulatorPreferenceChange,
@@ -83,6 +82,9 @@ export default function FreePage() {
     const [feedbackPlans, setFeedbackPlans] = useState<
         readonly MessageFeedbackPlan[]
     >([])
+    const [instructionFallback, setInstructionFallback] = useState<
+        string | undefined
+    >()
     const snapshot = useMemo(() => getTypingSessionSnapshot(session), [session])
     const keyboardBindings = useMemo(
         () => createWebKeyboardBindings(preferences.keyboardBindings),
@@ -90,24 +92,20 @@ export default function FreePage() {
     )
     const speechOutput = useMemo(createBrowserSpeechOutput, [])
     const soundOutput = useMemo(createWebSoundOutput, [])
-    const lastSpeechRequest = useRef<SpeechRequest | undefined>(undefined)
-
-    const speak = useCallback(
-        (text: string, purpose: SpeechRequest['purpose']) => {
-            const speech = preferencesRef.current.feedback.speech
-            if (!speech.enabled || speechOutput === undefined) return
-            const { enabled: _enabled, ...speechSettings } = speech
-            const request = Object.freeze({ text, purpose, ...speechSettings })
-            lastSpeechRequest.current = request
-            void speechOutput.speak(request).then((result) => {
-                if (result === 'unavailable' || result === 'failed') {
+    const multimodalFeedback = useMemo(
+        () =>
+            createMultimodalFeedbackController({
+                speechOutput,
+                soundOutput,
+                getPreferences: () => preferencesRef.current.feedback,
+                onSpeechUnavailable: () =>
                     setPreferencesNotice(
                         'A leitura falada está indisponível; o texto e as mensagens acessíveis continuam ativos.',
-                    )
-                }
-            })
-        },
-        [speechOutput],
+                    ),
+                presentInstructionFallback: setInstructionFallback,
+                presentAccessibleFallback: setFeedbackPlans,
+            }),
+        [soundOutput, speechOutput],
     )
 
     const dispatch = useCallback(
@@ -122,42 +120,26 @@ export default function FreePage() {
             )
             feedbackCoordinatorRef.current = feedback.state
             if (feedback.plans.length > 0) {
-                setFeedbackPlans(feedback.plans)
-                feedback.plans.forEach((plan) => {
-                    if (plan.interruption !== 'none') speechOutput?.cancel()
-                    speak(resolveFeedbackMessage(plan), 'status')
-                })
+                setFeedbackPlans(
+                    multimodalFeedback.deliverPlans(feedback.plans),
+                )
             }
         },
-        [speak, speechOutput],
+        [multimodalFeedback],
     )
 
     const handlePresentationAction = useCallback(
         (action: LegacyFreeModeAction) => {
             if (action === 'instructions-requested') {
-                const instructions =
-                    'Use F, D, S, J, K e L para formar acordes Braille. Use Espaço, Backspace e Q para editar.'
-                if (preferences.feedback.speech.enabled) {
-                    speak(instructions, 'instruction')
-                } else if (preferences.feedback.sounds.enabled) {
-                    void soundOutput.play({
-                        type: 'editorial',
-                        id: 'free-instructions',
-                    })
-                }
+                multimodalFeedback.requestInstructions()
                 return
             }
             if (action === 'speech-stopped') {
-                speechOutput?.cancel()
-                soundOutput.cancel()
+                multimodalFeedback.stop()
                 return
             }
             if (action === 'speech-repeated') {
-                if (
-                    preferences.feedback.speech.enabled &&
-                    lastSpeechRequest.current !== undefined
-                )
-                    void speechOutput?.speak(lastSpeechRequest.current)
+                multimodalFeedback.repeatSpeech()
                 return
             }
 
@@ -169,7 +151,7 @@ export default function FreePage() {
                     type: 'set-view',
                     view: showingBraille ? 'ink' : 'braille',
                 }
-            } else if (action === 'output-audio-toggled') {
+            } else if (action === 'speech-toggled') {
                 change = {
                     type: 'set-speech-enabled',
                     enabled: !preferences.feedback.speech.enabled,
@@ -182,6 +164,7 @@ export default function FreePage() {
             }
 
             const updated = applySimulatorPreferenceChange(preferences, change)
+            multimodalFeedback.applyPreferences(updated.feedback)
             setPreferences(updated)
             const saveResult = saveSimulatorPreferences(
                 preferencesStorage,
@@ -197,21 +180,22 @@ export default function FreePage() {
                       : undefined,
             )
         },
-        [preferences, preferencesStorage, soundOutput, speak, speechOutput],
+        [multimodalFeedback, preferences, preferencesStorage, speechOutput],
     )
 
     const presentationPreferences = useMemo(
         () => ({
             ...preferences.presentation,
             keyboardAudioEnabled: preferences.feedback.sounds.enabled,
+            speechEnabled: preferences.feedback.speech.enabled,
+            soundsEnabled: preferences.feedback.sounds.enabled,
         }),
         [preferences],
     )
 
     const playMachineSound = useCallback(() => {
-        if (preferencesRef.current.feedback.sounds.enabled)
-            void soundOutput.play({ type: 'machine-key' })
-    }, [soundOutput])
+        multimodalFeedback.playMachineKey()
+    }, [multimodalFeedback])
 
     return (
         <>
@@ -220,6 +204,9 @@ export default function FreePage() {
                     <div role="alert">{preferencesNotice}</div>
                 )}
                 <AccessibleFeedback plans={feedbackPlans} />
+                {instructionFallback !== undefined && (
+                    <p aria-live="polite">{instructionFallback}</p>
+                )}
                 <FreeTypingSession
                     snapshot={snapshot}
                     dispatch={dispatch}

--- a/src/feedback/README.md
+++ b/src/feedback/README.md
@@ -54,8 +54,20 @@ o feedback falado automático está desligado. Assim, I e R continuam sendo
 ações disponíveis; P interrompe a saída corrente em qualquer estado de captura.
 Quando O ativa a leitura automática, a Interpretação Braille fornece o novo
 Símbolo textual produzido; espaços recebem um nome pronunciável e operações de
-edição permanecem silenciosas. Unidades por palavra, linha e documento ainda
-dependem da política configurável de leitura.
+edição permanecem silenciosas. Caracteres acentuados do perfil português usam
+nomes inequívocos, como “a agudo”, “a til” e “a circunflexo”, sem alterar a
+Interpretação Braille. Unidades por palavra, linha e documento ainda dependem da
+política configurável de leitura.
+
+A naturalidade, a qualidade e a disponibilidade das vozes Web Speech pertencem
+ao navegador e ao sistema operacional, portanto podem variar entre ambientes.
+Na validação manual em Linux, a voz disponível foi considerada muito robótica e
+por vezes difícil de compreender. Essa implementação é somente a baseline
+técnica da Alpha 2: ela não representa a qualidade de voz pretendida para o
+produto, não garante uma voz idêntica nem operação offline em todas as
+plataformas e exige uma melhoria substancial. A #80 acompanha a pesquisa e a
+adoção de um motor em português mais natural e consistente, capaz de substituir
+o adapter atual.
 
 O `AudioProvider` permanece temporariamente apenas para efeitos e destinos
 legados. Conteúdo falado do menu e do Modo desafio já usa Web Speech por essa

--- a/src/feedback/README.md
+++ b/src/feedback/README.md
@@ -40,13 +40,25 @@ coordenador. `ui/feedback/AccessibleFeedback.tsx` mostra cada plano preservado e
 atualiza uma região viva com o conteúdo equivalente sem mover o foco da área de
 digitação.
 
-Áudio e fala substituíveis serão conectados no corte seguinte da capacidade;
-esta etapa cobre o texto visual e as mensagens programáticas da issue #43.
+O adapter Web Speech recebe texto canônico, localidade BCP 47, finalidade e
+características portáveis. Ele seleciona primeiro a localidade completa, depois
+o idioma-base, sem transformar o nome bruto de uma voz em preferência.
+
+O adapter web de sons recebe identificadores semânticos e resolve assets dentro
+do catálogo. No Modo livre, leitura e sons podem ser ligados, desligados,
+repetidos ou interrompidos pelos atalhos documentados. Ausência ou falha da
+plataforma não remove o texto nem a semântica acessível.
+
+O `AudioProvider` permanece temporariamente apenas para destinos legados. O
+Modo livre não o consome, evitando feedback duplicado; ele será removido quando
+o último destino legado for substituído.
 
 ## Estratégia de testes
 
 - `feedback.test.ts` verifica decisões do planejador pela interface pública;
 - `tests/contracts/feedback-output.test.ts` verifica isolamento entre adapters;
+- `tests/contracts/web-speech-output.test.ts` verifica a Web Speech substituída;
+- `tests/contracts/web-sound-output.test.ts` verifica sons determinísticos;
 - `tests/journeys/free-mode.test.tsx` verifica equivalência de conteúdo e
   preservação de foco pelo DOM acessível.
 

--- a/src/feedback/README.md
+++ b/src/feedback/README.md
@@ -49,9 +49,19 @@ do catálogo. No Modo livre, leitura e sons podem ser ligados, desligados,
 repetidos ou interrompidos pelos atalhos documentados. Ausência ou falha da
 plataforma não remove o texto nem a semântica acessível.
 
-O `AudioProvider` permanece temporariamente apenas para destinos legados. O
-Modo livre não o consome, evitando feedback duplicado; ele será removido quando
-o último destino legado for substituído.
+Instruções e repetições solicitadas explicitamente usam Web Speech mesmo quando
+o feedback falado automático está desligado. Assim, I e R continuam sendo
+ações disponíveis; P interrompe a saída corrente em qualquer estado de captura.
+Quando O ativa a leitura automática, a Interpretação Braille fornece o novo
+Símbolo textual produzido; espaços recebem um nome pronunciável e operações de
+edição permanecem silenciosas. Unidades por palavra, linha e documento ainda
+dependem da política configurável de leitura.
+
+O `AudioProvider` permanece temporariamente apenas para efeitos e destinos
+legados. Conteúdo falado do menu e do Modo desafio já usa Web Speech por essa
+ponte transitória; os MP3s permanecem ativos somente onde ainda representam
+efeitos ou conteúdo legado não migrado. O Modo livre não consome o provider,
+evitando feedback duplicado, e cancela fala e sons ao sair da experiência.
 
 ## Estratégia de testes
 

--- a/src/feedback/adapters/web/sound/webSound.ts
+++ b/src/feedback/adapters/web/sound/webSound.ts
@@ -1,0 +1,57 @@
+import { resolveSoundAsset } from '../../../catalog/sounds'
+import type { SoundCue, SoundOutput, SoundResult } from '../../../sound'
+
+export type WebAudio = {
+    currentTime: number
+    onended: null | ((event: Event) => unknown)
+    play(): Promise<void>
+    pause(): void
+}
+
+export type WebAudioFactory = (asset: string) => WebAudio
+
+/** Plays semantic sound cues through replaceable browser audio elements. */
+export const createWebSoundOutput = (
+    createAudio: WebAudioFactory = (asset) => new Audio(asset),
+    random: () => number = Math.random,
+): SoundOutput => {
+    let current: WebAudio | undefined
+    let cancelCurrent: (() => void) | undefined
+
+    return {
+        play: async (cue: SoundCue): Promise<SoundResult> => {
+            const asset = resolveSoundAsset(cue, random)
+            if (asset === undefined) return 'unavailable'
+            let audio: WebAudio
+            try {
+                audio = createAudio(asset)
+            } catch {
+                return 'failed'
+            }
+            current = audio
+            return new Promise((resolve) => {
+                let settled = false
+                const finish = (result: SoundResult) => {
+                    if (settled) return
+                    settled = true
+                    if (current === audio) current = undefined
+                    resolve(result)
+                }
+                cancelCurrent = () => finish('cancelled')
+                audio.onended = () => finish('completed')
+                try {
+                    void audio.play().catch(() => finish('failed'))
+                } catch {
+                    finish('failed')
+                }
+            })
+        },
+        cancel: () => {
+            if (current === undefined) return
+            current.pause()
+            current.currentTime = 0
+            cancelCurrent?.()
+            current = undefined
+        },
+    }
+}

--- a/src/feedback/adapters/web/sound/webSound.ts
+++ b/src/feedback/adapters/web/sound/webSound.ts
@@ -1,6 +1,7 @@
 import { resolveSoundAsset } from '../../../catalog/sounds'
 import type { SoundCue, SoundOutput, SoundResult } from '../../../sound'
 
+/** Minimum replaceable browser-audio player used by the sound adapter. */
 export type WebAudio = {
     currentTime: number
     onended: null | ((event: Event) => unknown)
@@ -8,6 +9,7 @@ export type WebAudio = {
     pause(): void
 }
 
+/** Creates one player for an adapter-owned asset path. */
 export type WebAudioFactory = (asset: string) => WebAudio
 
 /** Plays semantic sound cues through replaceable browser audio elements. */
@@ -20,6 +22,12 @@ export const createWebSoundOutput = (
 
     return {
         play: async (cue: SoundCue): Promise<SoundResult> => {
+            if (current !== undefined) {
+                current.pause()
+                current.currentTime = 0
+                cancelCurrent?.()
+                current = undefined
+            }
             const asset = resolveSoundAsset(cue, random)
             if (asset === undefined) return 'unavailable'
             let audio: WebAudio

--- a/src/feedback/adapters/web/speech/webSpeech.ts
+++ b/src/feedback/adapters/web/speech/webSpeech.ts
@@ -110,10 +110,12 @@ export const createBrowserSpeechOutput = (): SpeechOutput | undefined => {
         typeof globalThis.SpeechSynthesisUtterance === 'undefined'
     )
         return undefined
+    const nativeSynthesis = globalThis.speechSynthesis
+    const NativeUtterance = globalThis.SpeechSynthesisUtterance
     return createWebSpeechOutput(
         {
             getVoices: () =>
-                globalThis.speechSynthesis.getVoices().map((voice) => ({
+                nativeSynthesis.getVoices().map((voice) => ({
                     name: voice.name,
                     lang: voice.lang,
                     default: voice.default,
@@ -122,9 +124,9 @@ export const createBrowserSpeechOutput = (): SpeechOutput | undefined => {
                 })),
             speak: (utterance) => {
                 const native =
-                    utterance.platformValue instanceof SpeechSynthesisUtterance
+                    utterance.platformValue instanceof NativeUtterance
                         ? utterance.platformValue
-                        : new SpeechSynthesisUtterance(utterance.text)
+                        : new NativeUtterance(utterance.text)
                 native.lang = utterance.lang ?? ''
                 native.voice = (utterance.voice?.platformValue ??
                     null) as SpeechSynthesisVoice | null
@@ -134,22 +136,18 @@ export const createBrowserSpeechOutput = (): SpeechOutput | undefined => {
                 native.onend = () => utterance.onend?.()
                 native.onerror = (event) =>
                     utterance.onerror?.({ error: event.error })
-                globalThis.speechSynthesis.speak(native)
+                nativeSynthesis.speak(native)
             },
-            cancel: () => globalThis.speechSynthesis.cancel(),
+            cancel: () => nativeSynthesis.cancel(),
             addEventListener:
-                typeof globalThis.speechSynthesis.addEventListener ===
-                'function'
+                typeof nativeSynthesis.addEventListener === 'function'
                     ? (type, listener) =>
-                          globalThis.speechSynthesis.addEventListener(
-                              type,
-                              listener,
-                          )
+                          nativeSynthesis.addEventListener(type, listener)
                     : undefined,
         },
         (text) => ({
             text,
-            platformValue: new SpeechSynthesisUtterance(text),
+            platformValue: new NativeUtterance(text),
         }),
     )
 }

--- a/src/feedback/adapters/web/speech/webSpeech.ts
+++ b/src/feedback/adapters/web/speech/webSpeech.ts
@@ -1,0 +1,136 @@
+import type { SpeechOutput, SpeechRequest, SpeechResult } from '../../../speech'
+
+export type WebSpeechVoice = Readonly<{
+    name: string
+    lang: string
+    default: boolean
+    localService: boolean
+    platformValue?: unknown
+}>
+
+export type WebSpeechUtterance = {
+    text: string
+    lang?: string
+    voice?: WebSpeechVoice
+    rate?: number
+    pitch?: number
+    volume?: number
+    onend?: () => void
+    onerror?: (event: Readonly<{ error?: string }>) => void
+    platformValue?: unknown
+}
+
+export type WebSpeechSynthesis = Readonly<{
+    getVoices(): readonly WebSpeechVoice[]
+    speak(utterance: WebSpeechUtterance): void
+    cancel(): void
+}>
+
+export type WebSpeechUtteranceFactory = (text: string) => WebSpeechUtterance
+
+const selectVoice = (
+    voices: readonly WebSpeechVoice[],
+    request: SpeechRequest,
+): WebSpeechVoice | undefined => {
+    const exact = voices.filter(
+        (voice) => voice.lang.toLowerCase() === request.locale.toLowerCase(),
+    )
+    const language = request.locale.split('-')[0]?.toLowerCase()
+    const compatible =
+        exact.length > 0
+            ? exact
+            : voices.filter(
+                  (voice) =>
+                      voice.lang.split('-')[0]?.toLowerCase() === language,
+              )
+    if (request.voicePreference === 'local') {
+        return compatible.find((voice) => voice.localService) ?? compatible[0]
+    }
+    return compatible.find((voice) => voice.default) ?? compatible[0]
+}
+
+/** Adapts Web Speech without exposing platform voice objects in preferences. */
+export const createWebSpeechOutput = (
+    synthesis: WebSpeechSynthesis,
+    createUtterance: WebSpeechUtteranceFactory,
+): SpeechOutput => {
+    let cancelCurrent: (() => void) | undefined
+    return {
+        speak: async (request): Promise<SpeechResult> => {
+            const voice = selectVoice(synthesis.getVoices(), request)
+            if (voice === undefined) return 'unavailable'
+            const utterance = createUtterance(request.text)
+            Object.assign(utterance, {
+                lang: request.locale,
+                voice,
+                rate: request.rate,
+                pitch: request.pitch,
+                volume: request.volume,
+            })
+            return new Promise((resolve) => {
+                let settled = false
+                const finish = (result: SpeechResult) => {
+                    if (settled) return
+                    settled = true
+                    cancelCurrent = undefined
+                    resolve(result)
+                }
+                cancelCurrent = () => finish('cancelled')
+                utterance.onend = () => finish('completed')
+                utterance.onerror = (event) =>
+                    finish(event.error === 'canceled' ? 'cancelled' : 'failed')
+                try {
+                    synthesis.speak(utterance)
+                } catch {
+                    finish('failed')
+                }
+            })
+        },
+        cancel: () => {
+            synthesis.cancel()
+            cancelCurrent?.()
+        },
+    }
+}
+
+/** Discovers the browser implementation lazily and reports absence safely. */
+export const createBrowserSpeechOutput = (): SpeechOutput | undefined => {
+    if (
+        typeof globalThis.speechSynthesis === 'undefined' ||
+        typeof globalThis.SpeechSynthesisUtterance === 'undefined'
+    )
+        return undefined
+    return createWebSpeechOutput(
+        {
+            getVoices: () =>
+                globalThis.speechSynthesis.getVoices().map((voice) => ({
+                    name: voice.name,
+                    lang: voice.lang,
+                    default: voice.default,
+                    localService: voice.localService,
+                    platformValue: voice,
+                })),
+            speak: (utterance) => {
+                const native =
+                    utterance.platformValue instanceof SpeechSynthesisUtterance
+                        ? utterance.platformValue
+                        : new SpeechSynthesisUtterance(utterance.text)
+                native.lang = utterance.lang ?? ''
+                native.voice = (utterance.voice?.platformValue ??
+                    null) as SpeechSynthesisVoice | null
+                native.rate = utterance.rate ?? 1
+                native.pitch = utterance.pitch ?? 1
+                native.volume = utterance.volume ?? 1
+                native.onend = () => utterance.onend?.()
+                native.onerror = (event) =>
+                    utterance.onerror?.({ error: event.error })
+                globalThis.speechSynthesis.speak(native)
+            },
+            cancel: () => globalThis.speechSynthesis.cancel(),
+        },
+        (text) => ({
+            text,
+            platformValue: new SpeechSynthesisUtterance(text),
+        }),
+    )
+}

--- a/src/feedback/adapters/web/speech/webSpeech.ts
+++ b/src/feedback/adapters/web/speech/webSpeech.ts
@@ -1,5 +1,6 @@
 import type { SpeechOutput, SpeechRequest, SpeechResult } from '../../../speech'
 
+/** Portable projection of a platform voice; `name` is never persisted. */
 export type WebSpeechVoice = Readonly<{
     name: string
     lang: string
@@ -8,6 +9,7 @@ export type WebSpeechVoice = Readonly<{
     platformValue?: unknown
 }>
 
+/** Mutable utterance boundary populated before platform playback. */
 export type WebSpeechUtterance = {
     text: string
     lang?: string
@@ -20,12 +22,15 @@ export type WebSpeechUtterance = {
     platformValue?: unknown
 }
 
+/** Minimum Web Speech capability required by the adapter. */
 export type WebSpeechSynthesis = Readonly<{
     getVoices(): readonly WebSpeechVoice[]
     speak(utterance: WebSpeechUtterance): void
     cancel(): void
+    addEventListener?(type: 'voiceschanged', listener: () => void): void
 }>
 
+/** Creates an utterance owned by the target speech platform. */
 export type WebSpeechUtteranceFactory = (text: string) => WebSpeechUtterance
 
 const selectVoice = (
@@ -55,9 +60,14 @@ export const createWebSpeechOutput = (
     createUtterance: WebSpeechUtteranceFactory,
 ): SpeechOutput => {
     let cancelCurrent: (() => void) | undefined
+    let voices = synthesis.getVoices()
+    synthesis.addEventListener?.('voiceschanged', () => {
+        voices = synthesis.getVoices()
+    })
     return {
         speak: async (request): Promise<SpeechResult> => {
-            const voice = selectVoice(synthesis.getVoices(), request)
+            voices = synthesis.getVoices()
+            const voice = selectVoice(voices, request)
             if (voice === undefined) return 'unavailable'
             const utterance = createUtterance(request.text)
             Object.assign(utterance, {
@@ -127,6 +137,15 @@ export const createBrowserSpeechOutput = (): SpeechOutput | undefined => {
                 globalThis.speechSynthesis.speak(native)
             },
             cancel: () => globalThis.speechSynthesis.cancel(),
+            addEventListener:
+                typeof globalThis.speechSynthesis.addEventListener ===
+                'function'
+                    ? (type, listener) =>
+                          globalThis.speechSynthesis.addEventListener(
+                              type,
+                              listener,
+                          )
+                    : undefined,
         },
         (text) => ({
             text,

--- a/src/feedback/catalog/instructions.ts
+++ b/src/feedback/catalog/instructions.ts
@@ -1,0 +1,7 @@
+/** Canonical Portuguese instructions for the Free Mode experience. */
+export const freeModeInstructionsPortuguese =
+    'As teclas F, D, S, J, K e L correspondem, respectivamente, aos pontos 1, 2, 3, 4, 5 e 6 da cela Braille. A tecla Espaço corresponde a uma cela vazia. A tecla Backspace remove uma cela. A tecla Q faz uma quebra de linha. Pressione I para ouvir as instruções, T para ver o texto a tinta ou em Braille, a letra O para ligar ou desligar a leitura falada e M para ligar ou desligar os sons da máquina.'
+
+/** Canonical Portuguese instructions for the Challenge Mode experience. */
+export const challengeModeInstructionsPortuguese =
+    'No modo desafio, você terá que digitar a palavra exibida e pronunciada. Pressione Enter para verificar sua resposta. Pressione R para ouvir a palavra.'

--- a/src/feedback/catalog/sounds.ts
+++ b/src/feedback/catalog/sounds.ts
@@ -1,9 +1,5 @@
 import type { SoundCue } from '../sound'
 
-const editorialAssets: Readonly<Record<string, string>> = Object.freeze({
-    'free-instructions': 'assets/audio/views/free/instrucoes-modo-livre.mp3',
-})
-
 const machineKeyAssets = Object.freeze([
     'assets/audio/keys/key-pressed-1.mp3',
     'assets/audio/keys/key-pressed-2.mp3',
@@ -15,7 +11,7 @@ export const resolveSoundAsset = (
     cue: SoundCue,
     random: () => number,
 ): string | undefined => {
-    if (cue.type === 'editorial') return editorialAssets[cue.id]
+    if (cue.type === 'editorial') return undefined
     const index = Math.floor(random() * machineKeyAssets.length)
     return machineKeyAssets[index]
 }

--- a/src/feedback/catalog/sounds.ts
+++ b/src/feedback/catalog/sounds.ts
@@ -1,0 +1,21 @@
+import type { SoundCue } from '../sound'
+
+const editorialAssets: Readonly<Record<string, string>> = Object.freeze({
+    'free-instructions': 'assets/audio/views/free/instrucoes-modo-livre.mp3',
+})
+
+const machineKeyAssets = Object.freeze([
+    'assets/audio/keys/key-pressed-1.mp3',
+    'assets/audio/keys/key-pressed-2.mp3',
+    'assets/audio/keys/key-pressed-3.mp3',
+    'assets/audio/keys/key-pressed-4.mp3',
+])
+
+export const resolveSoundAsset = (
+    cue: SoundCue,
+    random: () => number,
+): string | undefined => {
+    if (cue.type === 'editorial') return editorialAssets[cue.id]
+    const index = Math.floor(random() * machineKeyAssets.length)
+    return machineKeyAssets[index]
+}

--- a/src/feedback/multimodal.ts
+++ b/src/feedback/multimodal.ts
@@ -1,3 +1,4 @@
+import { freeModeInstructionsPortuguese } from './catalog/instructions'
 import { resolvePortugueseFeedbackMessage } from './catalog/portuguese'
 import type { MessageFeedbackPlan } from './feedback'
 import type { SoundOutput } from './sound'
@@ -23,13 +24,11 @@ export type MultimodalFeedbackController = Readonly<{
     ): readonly MessageFeedbackPlan[]
     requestInstructions(): void
     repeatSpeech(): void
+    readProduction(text: string): void
     playMachineKey(): void
     applyPreferences(preferences: MultimodalFeedbackPreferences): void
     stop(): void
 }>
-
-const freeModeInstructions =
-    'Use F, D, S, J, K e L para formar acordes Braille. Use Espaço, Backspace e Q para editar.'
 
 /**
  * Coordinates channel policy without coupling pages to browser media APIs.
@@ -52,9 +51,10 @@ export const createMultimodalFeedbackController = (options: {
         text: string,
         purpose: SpeechRequest['purpose'],
         onUnavailable?: () => void,
+        requireEnabled = true,
     ) => {
         const speech = options.getPreferences().speech
-        if (!speech.enabled) return
+        if (requireEnabled && !speech.enabled) return
         if (options.speechOutput === undefined) {
             options.onSpeechUnavailable()
             onUnavailable?.()
@@ -97,34 +97,28 @@ export const createMultimodalFeedbackController = (options: {
                 : plans
         },
         requestInstructions: () => {
-            const preferences = options.getPreferences()
-            if (preferences.speech.enabled) {
-                speak(freeModeInstructions, 'instruction', () =>
-                    options.presentInstructionFallback(freeModeInstructions),
+            if (options.speechOutput !== undefined) {
+                speak(
+                    freeModeInstructionsPortuguese,
+                    'instruction',
+                    () =>
+                        options.presentInstructionFallback(
+                            freeModeInstructionsPortuguese,
+                        ),
+                    false,
                 )
-            } else if (preferences.sounds.enabled) {
-                void options.soundOutput
-                    .play({
-                        type: 'editorial',
-                        id: 'free-instructions',
-                    })
-                    .then((result) => {
-                        if (result === 'unavailable' || result === 'failed')
-                            options.presentInstructionFallback(
-                                freeModeInstructions,
-                            )
-                    })
             } else {
-                options.presentInstructionFallback(freeModeInstructions)
+                options.onSpeechUnavailable()
+                options.presentInstructionFallback(
+                    freeModeInstructionsPortuguese,
+                )
             }
         },
         repeatSpeech: () => {
-            if (
-                options.getPreferences().speech.enabled &&
-                lastSpeechRequest !== undefined
-            )
+            if (lastSpeechRequest !== undefined)
                 void options.speechOutput?.speak(lastSpeechRequest)
         },
+        readProduction: (text) => speak(text, 'reading'),
         playMachineKey: () => {
             if (options.getPreferences().sounds.enabled)
                 void options.soundOutput.play({ type: 'machine-key' })

--- a/src/feedback/multimodal.ts
+++ b/src/feedback/multimodal.ts
@@ -1,0 +1,141 @@
+import { resolvePortugueseFeedbackMessage } from './catalog/portuguese'
+import type { MessageFeedbackPlan } from './feedback'
+import type { SoundOutput } from './sound'
+import type { SpeechOutput, SpeechRequest } from './speech'
+
+/** Runtime choices required to coordinate optional speech and sound channels. */
+export type MultimodalFeedbackPreferences = Readonly<{
+    speech: Readonly<{
+        enabled: boolean
+        locale: string
+        voicePreference: SpeechRequest['voicePreference']
+        rate: number
+        pitch: number
+        volume: number
+    }>
+    sounds: Readonly<{ enabled: boolean }>
+}>
+
+/** Application-level controls for replaceable speech and sound outputs. */
+export type MultimodalFeedbackController = Readonly<{
+    deliverPlans(
+        plans: readonly MessageFeedbackPlan[],
+    ): readonly MessageFeedbackPlan[]
+    requestInstructions(): void
+    repeatSpeech(): void
+    playMachineKey(): void
+    applyPreferences(preferences: MultimodalFeedbackPreferences): void
+    stop(): void
+}>
+
+const freeModeInstructions =
+    'Use F, D, S, J, K e L para formar acordes Braille. Use Espaço, Backspace e Q para editar.'
+
+/**
+ * Coordinates channel policy without coupling pages to browser media APIs.
+ *
+ * Speech failures are reported through `onSpeechUnavailable`; they never reject
+ * an input transition. Repetition uses the last request issued by this
+ * controller, and stopping settles both currently active output channels.
+ */
+export const createMultimodalFeedbackController = (options: {
+    speechOutput: SpeechOutput | undefined
+    soundOutput: SoundOutput
+    getPreferences: () => MultimodalFeedbackPreferences
+    onSpeechUnavailable: () => void
+    presentInstructionFallback: (text: string) => void
+    presentAccessibleFallback: (plans: readonly MessageFeedbackPlan[]) => void
+}): MultimodalFeedbackController => {
+    let lastSpeechRequest: SpeechRequest | undefined
+
+    const speak = (
+        text: string,
+        purpose: SpeechRequest['purpose'],
+        onUnavailable?: () => void,
+    ) => {
+        const speech = options.getPreferences().speech
+        if (!speech.enabled) return
+        if (options.speechOutput === undefined) {
+            options.onSpeechUnavailable()
+            onUnavailable?.()
+            return
+        }
+        const { enabled: _enabled, ...settings } = speech
+        const request = Object.freeze({ text, purpose, ...settings })
+        lastSpeechRequest = request
+        void options.speechOutput.speak(request).then((result) => {
+            if (result === 'unavailable' || result === 'failed') {
+                options.onSpeechUnavailable()
+                onUnavailable?.()
+            }
+        })
+    }
+
+    return Object.freeze({
+        deliverPlans: (plans) => {
+            const speechEnabled =
+                options.getPreferences().speech.enabled &&
+                options.speechOutput !== undefined
+            plans.forEach((plan) => {
+                if (plan.interruption !== 'none') options.speechOutput?.cancel()
+                speak(
+                    resolvePortugueseFeedbackMessage(plan.message),
+                    'status',
+                    () => options.presentAccessibleFallback(plans),
+                )
+            })
+            return speechEnabled
+                ? plans.map((plan) =>
+                      Object.freeze({
+                          ...plan,
+                          channels: Object.freeze({
+                              ...plan.channels,
+                              accessible: 'off' as const,
+                          }),
+                      }),
+                  )
+                : plans
+        },
+        requestInstructions: () => {
+            const preferences = options.getPreferences()
+            if (preferences.speech.enabled) {
+                speak(freeModeInstructions, 'instruction', () =>
+                    options.presentInstructionFallback(freeModeInstructions),
+                )
+            } else if (preferences.sounds.enabled) {
+                void options.soundOutput
+                    .play({
+                        type: 'editorial',
+                        id: 'free-instructions',
+                    })
+                    .then((result) => {
+                        if (result === 'unavailable' || result === 'failed')
+                            options.presentInstructionFallback(
+                                freeModeInstructions,
+                            )
+                    })
+            } else {
+                options.presentInstructionFallback(freeModeInstructions)
+            }
+        },
+        repeatSpeech: () => {
+            if (
+                options.getPreferences().speech.enabled &&
+                lastSpeechRequest !== undefined
+            )
+                void options.speechOutput?.speak(lastSpeechRequest)
+        },
+        playMachineKey: () => {
+            if (options.getPreferences().sounds.enabled)
+                void options.soundOutput.play({ type: 'machine-key' })
+        },
+        applyPreferences: (preferences) => {
+            if (!preferences.speech.enabled) options.speechOutput?.cancel()
+            if (!preferences.sounds.enabled) options.soundOutput.cancel()
+        },
+        stop: () => {
+            options.speechOutput?.cancel()
+            options.soundOutput.cancel()
+        },
+    })
+}

--- a/src/feedback/public.ts
+++ b/src/feedback/public.ts
@@ -28,6 +28,11 @@ export {
     type SilentFeedbackPlan,
 } from './feedback'
 export {
+    createMultimodalFeedbackController,
+    type MultimodalFeedbackController,
+    type MultimodalFeedbackPreferences,
+} from './multimodal'
+export {
     executeFeedbackPlan,
     type FeedbackDelivery,
     type FeedbackExecutionResult,

--- a/src/feedback/public.ts
+++ b/src/feedback/public.ts
@@ -3,6 +3,10 @@ import type { MessageFeedbackPlan } from './feedback'
 
 export { createMemoryFeedbackOutput } from './adapters/memory/memory'
 export {
+    challengeModeInstructionsPortuguese,
+    freeModeInstructionsPortuguese,
+} from './catalog/instructions'
+export {
     createBrowserSpeechOutput,
     createWebSpeechOutput,
     type WebSpeechSynthesis,
@@ -38,6 +42,7 @@ export {
     type FeedbackExecutionResult,
     type FeedbackOutput,
 } from './output'
+export { resolveAutomaticReading } from './reading'
 export {
     type SpeechOutput,
     type SpeechRequest,

--- a/src/feedback/public.ts
+++ b/src/feedback/public.ts
@@ -3,6 +3,19 @@ import type { MessageFeedbackPlan } from './feedback'
 
 export { createMemoryFeedbackOutput } from './adapters/memory/memory'
 export {
+    createBrowserSpeechOutput,
+    createWebSpeechOutput,
+    type WebSpeechSynthesis,
+    type WebSpeechUtterance,
+    type WebSpeechUtteranceFactory,
+    type WebSpeechVoice,
+} from './adapters/web/speech/webSpeech'
+export {
+    createWebSoundOutput,
+    type WebAudio,
+    type WebAudioFactory,
+} from './adapters/web/sound/webSound'
+export {
     coordinateSessionFeedback,
     createFeedbackCoordinatorState,
     planSessionFeedback,
@@ -20,6 +33,12 @@ export {
     type FeedbackExecutionResult,
     type FeedbackOutput,
 } from './output'
+export {
+    type SpeechOutput,
+    type SpeechRequest,
+    type SpeechResult,
+} from './speech'
+export { type SoundCue, type SoundOutput, type SoundResult } from './sound'
 
 /** Resolves a presentable plan into the current product locale. */
 export const resolveFeedbackMessage = (plan: MessageFeedbackPlan): string =>

--- a/src/feedback/reading.ts
+++ b/src/feedback/reading.ts
@@ -11,6 +11,25 @@ const interpretedText = (interpretation: BrailleInterpretation): string =>
         .map((segment) => segment.text)
         .join('')
 
+const portugueseSpokenCharacters: Readonly<Record<string, string>> =
+    Object.freeze({
+        á: 'a agudo',
+        à: 'a grave',
+        â: 'a circunflexo',
+        ã: 'a til',
+        ç: 'c cedilha',
+        é: 'e agudo',
+        ê: 'e circunflexo',
+        í: 'i agudo',
+        ó: 'o agudo',
+        ô: 'o circunflexo',
+        õ: 'o til',
+        ú: 'u agudo',
+    })
+
+const resolveSpokenCharacter = (text: string): string =>
+    portugueseSpokenCharacters[text] ?? text
+
 /**
  * Resolves the smallest textual reading introduced by one production batch.
  *
@@ -33,5 +52,5 @@ export const resolveAutomaticReading = (
     const after = interpretedText(current)
     if (!after.startsWith(before) || after.length <= before.length)
         return undefined
-    return after.slice(before.length)
+    return resolveSpokenCharacter(after.slice(before.length))
 }

--- a/src/feedback/reading.ts
+++ b/src/feedback/reading.ts
@@ -1,0 +1,37 @@
+import type { BrailleInterpretation } from '../braille/public'
+import type { SessionEvent } from '../session/public'
+
+const interpretedText = (interpretation: BrailleInterpretation): string =>
+    interpretation.lines
+        .flatMap((line) => line.segments)
+        .filter(
+            (segment) =>
+                segment.status === 'interpreted' && segment.role === 'symbol',
+        )
+        .map((segment) => segment.text)
+        .join('')
+
+/**
+ * Resolves the smallest textual reading introduced by one production batch.
+ *
+ * Editing operations produce no reading. A blank cell receives an explicit
+ * name because whitespace alone is not intelligible in speech.
+ */
+export const resolveAutomaticReading = (
+    previous: BrailleInterpretation,
+    current: BrailleInterpretation,
+    events: readonly SessionEvent[],
+): string | undefined => {
+    const operation = [...events]
+        .reverse()
+        .find((event) => event.type === 'operation-produced')
+    if (operation?.type !== 'operation-produced') return undefined
+    if (operation.operation.type === 'space') return 'espaço'
+    if (operation.operation.type !== 'confirm-cell') return undefined
+
+    const before = interpretedText(previous)
+    const after = interpretedText(current)
+    if (!after.startsWith(before) || after.length <= before.length)
+        return undefined
+    return after.slice(before.length)
+}

--- a/src/feedback/sound.ts
+++ b/src/feedback/sound.ts
@@ -5,7 +5,12 @@ export type SoundCue =
 
 export type SoundResult = 'completed' | 'cancelled' | 'unavailable' | 'failed'
 
-/** Substitutable optional-sound seam. */
+/**
+ * Substitutable optional-sound seam.
+ *
+ * Starting a cue replaces the currently active cue. Results report platform
+ * absence and failures without throwing; `cancel` is safe when idle.
+ */
 export type SoundOutput = Readonly<{
     play(cue: SoundCue): Promise<SoundResult>
     cancel(): void

--- a/src/feedback/sound.ts
+++ b/src/feedback/sound.ts
@@ -1,0 +1,12 @@
+/** Semantic sound request independent of an asset path or platform player. */
+export type SoundCue =
+    | Readonly<{ type: 'machine-key' }>
+    | Readonly<{ type: 'editorial'; id: string }>
+
+export type SoundResult = 'completed' | 'cancelled' | 'unavailable' | 'failed'
+
+/** Substitutable optional-sound seam. */
+export type SoundOutput = Readonly<{
+    play(cue: SoundCue): Promise<SoundResult>
+    cancel(): void
+}>

--- a/src/feedback/speech.ts
+++ b/src/feedback/speech.ts
@@ -1,0 +1,19 @@
+/** Portable request for application-owned speech. */
+export type SpeechRequest = Readonly<{
+    text: string
+    locale: string
+    purpose: 'reading' | 'instruction' | 'status' | 'result'
+    voicePreference: 'default' | 'local'
+    rate: number
+    pitch: number
+    volume: number
+}>
+
+/** Observable completion state of one speech request. */
+export type SpeechResult = 'completed' | 'cancelled' | 'unavailable' | 'failed'
+
+/** Substitutable application-speech seam. */
+export type SpeechOutput = Readonly<{
+    speak(request: SpeechRequest): Promise<SpeechResult>
+    cancel(): void
+}>

--- a/src/feedback/speech.ts
+++ b/src/feedback/speech.ts
@@ -1,4 +1,11 @@
-/** Portable request for application-owned speech. */
+/**
+ * Portable request for application-owned speech.
+ *
+ * `locale` is a non-empty BCP 47 tag; rate is 0.1–10, pitch 0–2 and volume
+ * 0–1. `voicePreference` is deliberately logical and must never be replaced by
+ * a persisted platform voice name. Purpose lets adapters preserve the product
+ * distinction between reading, instructions, status and results.
+ */
 export type SpeechRequest = Readonly<{
     text: string
     locale: string
@@ -9,10 +16,15 @@ export type SpeechRequest = Readonly<{
     volume: number
 }>
 
-/** Observable completion state of one speech request. */
+/** Observable completion state; unavailable and failed requests never throw. */
 export type SpeechResult = 'completed' | 'cancelled' | 'unavailable' | 'failed'
 
-/** Substitutable application-speech seam. */
+/**
+ * Substitutable application-speech seam.
+ *
+ * `speak` settles once playback ends, is cancelled, is unavailable or fails.
+ * `cancel` settles the active request as cancelled and is safe when idle.
+ */
 export type SpeechOutput = Readonly<{
     speak(request: SpeechRequest): Promise<SpeechResult>
     cancel(): void

--- a/src/preferences/README.md
+++ b/src/preferences/README.md
@@ -7,10 +7,12 @@ migra seu formato serializado e oferece uma seam pequena para carregamento e
 persistência. Ela não conhece React, Sessão de digitação, Documento Braille,
 áudio nem APIs do navegador.
 
-O schema atual, identificado por `version: 1`, preserva:
+O schema atual, identificado por `version: 2`, preserva:
 
 - visualização Braille ou a tinta;
-- áudio da saída e do teclado;
+- leitura falada explícita com localidade, preferência lógica de voz,
+  velocidade, pitch e volume;
+- sons opcionais da máquina;
 - códigos físicos associados aos controles configuráveis;
 - Modo de simulação Assistido ou Fidelidade física.
 
@@ -35,7 +37,7 @@ O carregamento sempre devolve preferências válidas e um resultado observável:
 | Status      | Significado                                                            |
 | ----------- | ---------------------------------------------------------------------- |
 | `loaded`    | O payload da versão atual foi validado.                                |
-| `migrated`  | Escolhas legadas da versão 0 foram convertidas para a versão atual.    |
+| `migrated`  | Escolhas das versões 0 ou 1 foram convertidas para a versão atual.     |
 | `defaulted` | Os padrões foram usados por ausência, invalidade ou indisponibilidade. |
 
 Payloads incompletos, códigos físicos vazios ou duplicados, versões desconhecidas
@@ -43,7 +45,8 @@ e JSON inválido não atravessam a interface. Falhas de leitura e escrita são
 convertidas em resultados; elas não interrompem nem revertem a Sessão de
 digitação corrente.
 
-Uma migração válida tenta gravar imediatamente o schema atual. Se essa gravação
+Snapshots da versão 1 recebem as novas preferências sem persistir nomes
+concretos de vozes. Uma migração válida tenta gravar imediatamente o schema atual. Se essa gravação
 falhar, as escolhas migradas continuam ativas na sessão corrente e o resultado
 expõe `migrationPersistence: 'failed'`.
 

--- a/src/preferences/preferences.test.ts
+++ b/src/preferences/preferences.test.ts
@@ -27,8 +27,6 @@ describe('Simulator preferences', () => {
             ...createDefaultSimulatorPreferences(),
             presentation: {
                 view: 'ink' as const,
-                outputAudioEnabled: false,
-                keyboardAudioEnabled: false,
             },
             simulationMode: 'physical-fidelity' as const,
         }
@@ -61,11 +59,43 @@ describe('Simulator preferences', () => {
             ...createDefaultSimulatorPreferences(),
             presentation: {
                 view: 'ink',
-                outputAudioEnabled: false,
-                keyboardAudioEnabled: true,
+            },
+            feedback: {
+                ...createDefaultSimulatorPreferences().feedback,
+                sounds: { enabled: true },
             },
         })
         expect(writes).toEqual([JSON.stringify(result.preferences)])
+    })
+
+    test('migrates version one into explicit speech and sound preferences', () => {
+        const versionOne = {
+            ...createDefaultSimulatorPreferences(),
+            version: 1,
+            presentation: {
+                ...createDefaultSimulatorPreferences().presentation,
+                outputAudioEnabled: true,
+                keyboardAudioEnabled: true,
+            },
+        }
+        const { feedback: _feedback, ...persistedVersionOne } = versionOne
+        const result = loadSimulatorPreferences({
+            read: () => JSON.stringify(persistedVersionOne),
+            write: () => undefined,
+        })
+
+        expect(result.status).toBe('migrated')
+        expect(result.preferences.feedback).toEqual({
+            speech: {
+                enabled: false,
+                locale: 'pt-BR',
+                voicePreference: 'default',
+                rate: 1,
+                pitch: 1,
+                volume: 1,
+            },
+            sounds: { enabled: true },
+        })
     })
 
     test('keeps migrated choices when persisting the new schema fails', () => {
@@ -166,19 +196,18 @@ describe('Simulator preferences', () => {
 
     test('updates persistent audio choices independently', () => {
         const initial = createDefaultSimulatorPreferences()
-        const withoutOutputAudio = applySimulatorPreferenceChange(initial, {
-            type: 'set-output-audio',
-            enabled: false,
+        const withSpeech = applySimulatorPreferenceChange(initial, {
+            type: 'set-speech-enabled',
+            enabled: true,
         })
-        const silent = applySimulatorPreferenceChange(withoutOutputAudio, {
-            type: 'set-keyboard-audio',
+        const silent = applySimulatorPreferenceChange(withSpeech, {
+            type: 'set-sounds-enabled',
             enabled: false,
         })
 
-        expect(silent.presentation).toEqual({
-            view: 'braille',
-            outputAudioEnabled: false,
-            keyboardAudioEnabled: false,
+        expect(silent.feedback).toEqual({
+            speech: { ...initial.feedback.speech, enabled: true },
+            sounds: { enabled: false },
         })
     })
 })

--- a/src/preferences/preferences.test.ts
+++ b/src/preferences/preferences.test.ts
@@ -90,7 +90,7 @@ describe('Simulator preferences', () => {
                 enabled: false,
                 locale: 'pt-BR',
                 voicePreference: 'default',
-                rate: 1,
+                rate: 0.9,
                 pitch: 1,
                 volume: 1,
             },

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -1,7 +1,14 @@
 /** Version of the persisted simulator-preferences schema. */
 export const simulatorPreferencesVersion = 2 as const
 
-/** Portable choices for application speech and optional machine sounds. */
+/**
+ * Portable choices for application speech and optional machine sounds.
+ *
+ * `locale` is a non-empty BCP 47 language tag. `voicePreference` selects a
+ * logical class rather than persisting a platform voice name: `default` uses
+ * the platform default compatible voice, while `local` prefers an installed
+ * voice. Web Speech ranges are rate 0.1–10, pitch 0–2 and volume 0–1.
+ */
 export type FeedbackPreferences = Readonly<{
     speech: Readonly<{
         enabled: boolean

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -272,7 +272,7 @@ export const createDefaultSimulatorPreferences = (): SimulatorPreferences =>
                 enabled: false,
                 locale: 'pt-BR',
                 voicePreference: 'default',
-                rate: 1,
+                rate: 0.9,
                 pitch: 1,
                 volume: 1,
             }),

--- a/src/preferences/preferences.ts
+++ b/src/preferences/preferences.ts
@@ -1,5 +1,18 @@
 /** Version of the persisted simulator-preferences schema. */
-export const simulatorPreferencesVersion = 1 as const
+export const simulatorPreferencesVersion = 2 as const
+
+/** Portable choices for application speech and optional machine sounds. */
+export type FeedbackPreferences = Readonly<{
+    speech: Readonly<{
+        enabled: boolean
+        locale: string
+        voicePreference: 'default' | 'local'
+        rate: number
+        pitch: number
+        volume: number
+    }>
+    sounds: Readonly<{ enabled: boolean }>
+}>
 
 /**
  * Physical keyboard codes selected for each configurable simulator action.
@@ -30,11 +43,10 @@ export type SimulatorPreferences = Readonly<{
     version: typeof simulatorPreferencesVersion
     presentation: Readonly<{
         view: 'braille' | 'ink'
-        outputAudioEnabled: boolean
-        keyboardAudioEnabled: boolean
     }>
     keyboardBindings: KeyboardBindingPreferences
     simulationMode: 'assisted' | 'physical-fidelity'
+    feedback: FeedbackPreferences
 }>
 
 /** Minimal persistence seam implemented by web and deterministic adapters. */
@@ -85,7 +97,7 @@ export type SimulatorPreferenceChange =
           view: 'braille' | 'ink'
       }>
     | Readonly<{
-          type: 'set-output-audio' | 'set-keyboard-audio'
+          type: 'set-speech-enabled' | 'set-sounds-enabled'
           enabled: boolean
       }>
 
@@ -132,18 +144,38 @@ const decodeCurrentPreferences = (
 ): SimulatorPreferences | undefined => {
     if (!isRecord(value) || value.version !== simulatorPreferencesVersion)
         return undefined
-    if (!isRecord(value.presentation) || !isRecord(value.keyboardBindings))
+    if (
+        !isRecord(value.presentation) ||
+        !isRecord(value.keyboardBindings) ||
+        !isRecord(value.feedback) ||
+        !isRecord(value.feedback.speech) ||
+        !isRecord(value.feedback.sounds)
+    )
         return undefined
 
     const keyboardBindings = value.keyboardBindings
-    const { view, outputAudioEnabled, keyboardAudioEnabled } =
-        value.presentation
+    const { view } = value.presentation
+    const speech = value.feedback.speech
+    const sounds = value.feedback.sounds
     if (
         (view !== 'braille' && view !== 'ink') ||
-        typeof outputAudioEnabled !== 'boolean' ||
-        typeof keyboardAudioEnabled !== 'boolean' ||
         (value.simulationMode !== 'assisted' &&
-            value.simulationMode !== 'physical-fidelity')
+            value.simulationMode !== 'physical-fidelity') ||
+        typeof speech.enabled !== 'boolean' ||
+        typeof speech.locale !== 'string' ||
+        speech.locale.length === 0 ||
+        (speech.voicePreference !== 'default' &&
+            speech.voicePreference !== 'local') ||
+        typeof speech.rate !== 'number' ||
+        speech.rate < 0.1 ||
+        speech.rate > 10 ||
+        typeof speech.pitch !== 'number' ||
+        speech.pitch < 0 ||
+        speech.pitch > 2 ||
+        typeof speech.volume !== 'number' ||
+        speech.volume < 0 ||
+        speech.volume > 1 ||
+        typeof sounds.enabled !== 'boolean'
     ) {
         return undefined
     }
@@ -163,13 +195,34 @@ const decodeCurrentPreferences = (
         version: simulatorPreferencesVersion,
         presentation: Object.freeze({
             view,
-            outputAudioEnabled,
-            keyboardAudioEnabled,
         }),
         keyboardBindings: Object.freeze(
             bindings as unknown as KeyboardBindingPreferences,
         ),
         simulationMode: value.simulationMode,
+        feedback: Object.freeze({
+            speech: Object.freeze({
+                enabled: speech.enabled,
+                locale: speech.locale,
+                voicePreference: speech.voicePreference,
+                rate: speech.rate,
+                pitch: speech.pitch,
+                volume: speech.volume,
+            }),
+            sounds: Object.freeze({ enabled: sounds.enabled }),
+        }),
+    })
+}
+
+const migrateVersionOnePreferences = (
+    value: unknown,
+): SimulatorPreferences | undefined => {
+    if (!isRecord(value) || value.version !== 1) return undefined
+    const candidate = { ...value, version: simulatorPreferencesVersion }
+    const defaults = createDefaultSimulatorPreferences()
+    return decodeCurrentPreferences({
+        ...candidate,
+        feedback: defaults.feedback,
     })
 }
 
@@ -190,8 +243,10 @@ const migrateLegacyPreferences = (
         ...defaults,
         presentation: Object.freeze({
             view: value.showBraille ? 'braille' : 'ink',
-            outputAudioEnabled: !value.outputMuted,
-            keyboardAudioEnabled: !value.keyboardMuted,
+        }),
+        feedback: Object.freeze({
+            ...defaults.feedback,
+            sounds: Object.freeze({ enabled: !value.keyboardMuted }),
         }),
     })
 }
@@ -202,11 +257,20 @@ export const createDefaultSimulatorPreferences = (): SimulatorPreferences =>
         version: simulatorPreferencesVersion,
         presentation: Object.freeze({
             view: 'braille',
-            outputAudioEnabled: true,
-            keyboardAudioEnabled: true,
         }),
         keyboardBindings: defaultKeyboardBindings(),
         simulationMode: 'assisted',
+        feedback: Object.freeze({
+            speech: Object.freeze({
+                enabled: false,
+                locale: 'pt-BR',
+                voicePreference: 'default',
+                rate: 1,
+                pitch: 1,
+                volume: 1,
+            }),
+            sounds: Object.freeze({ enabled: true }),
+        }),
     })
 
 /**
@@ -242,7 +306,9 @@ export const loadSimulatorPreferences = (
         if (preferences !== undefined) {
             return Object.freeze({ preferences, status: 'loaded' })
         }
-        const migrated = migrateLegacyPreferences(value)
+        const migrated =
+            migrateVersionOnePreferences(value) ??
+            migrateLegacyPreferences(value)
         if (migrated !== undefined) {
             let migrationPersistence: 'saved' | 'failed' = 'saved'
             try {
@@ -308,15 +374,25 @@ export const applySimulatorPreferenceChange = (
     const presentation = {
         ...preferences.presentation,
         ...(change.type === 'set-view' ? { view: change.view } : {}),
-        ...(change.type === 'set-output-audio'
-            ? { outputAudioEnabled: change.enabled }
-            : {}),
-        ...(change.type === 'set-keyboard-audio'
-            ? { keyboardAudioEnabled: change.enabled }
-            : {}),
+    }
+    const feedback = {
+        ...preferences.feedback,
+        speech: Object.freeze({
+            ...preferences.feedback.speech,
+            ...(change.type === 'set-speech-enabled'
+                ? { enabled: change.enabled }
+                : {}),
+        }),
+        sounds: Object.freeze({
+            ...preferences.feedback.sounds,
+            ...(change.type === 'set-sounds-enabled'
+                ? { enabled: change.enabled }
+                : {}),
+        }),
     }
     return Object.freeze({
         ...preferences,
         presentation: Object.freeze(presentation),
+        feedback: Object.freeze(feedback),
     })
 }

--- a/src/preferences/public.ts
+++ b/src/preferences/public.ts
@@ -6,6 +6,7 @@ export {
     saveSimulatorPreferences,
     simulatorPreferencesVersion,
     type KeyboardBindingPreferences,
+    type FeedbackPreferences,
     type EffectiveSessionConfigurationResult,
     type ExperienceRequirements,
     type PreferencesLoadResult,

--- a/src/providers/AudioProvider.tsx
+++ b/src/providers/AudioProvider.tsx
@@ -1,6 +1,12 @@
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext, useMemo, useRef } from 'react'
 import type { PropsWithChildren } from 'react'
-import { Cell } from '../domain/Cell'
+import { Cell, cellToString } from '../domain/Cell'
+import {
+    challengeModeInstructionsPortuguese,
+    createBrowserSpeechOutput,
+    freeModeInstructionsPortuguese,
+    type SpeechRequest,
+} from '../feedback/public'
 
 const AudioContext = createContext({
     // Menu players
@@ -29,6 +35,7 @@ const AudioContext = createContext({
     playWordAudio: (_: string) => Promise.reject<void>(),
     playRightAnswer: (_: () => void) => Promise.reject<void>(),
     playWrongAnswer: () => Promise.reject<void>(),
+    stopAllAudio: () => {},
 })
 
 export function useAudioContext() {
@@ -36,49 +43,75 @@ export function useAudioContext() {
 }
 
 export default function AudioProvider({ children }: PropsWithChildren) {
-    const [currentPlaying, setCurrentPlaying] =
-        useState<HTMLAudioElement | null>(null)
+    const currentPlaying = useRef<HTMLAudioElement | null>(null)
+    const speechOutput = useMemo(createBrowserSpeechOutput, [])
+
+    const speak = async (
+        text: string,
+        purpose: SpeechRequest['purpose'],
+        onEnded = () => {},
+    ) => {
+        stopAllAudio()
+        if (speechOutput === undefined) return
+        const result = await speechOutput.speak({
+            text,
+            locale: 'pt-BR',
+            purpose,
+            voicePreference: 'default',
+            rate: 0.9,
+            pitch: 1,
+            volume: 1,
+        })
+        if (result === 'completed') onEnded()
+    }
 
     // Menu players
     async function playMainMenuAudio() {
-        return playAudio(getMainMenuAudio())
+        return speak('Menu principal da Máquina Den Braille', 'status')
     }
 
     async function playFreeModeAudio() {
-        return playAudio(getFreeModeAudio())
+        return speak('Modo livre', 'status')
     }
 
     async function playChallengeModeAudio() {
-        return playAudio(getChallengeModeAudio())
+        return speak('Modo desafio', 'status')
     }
 
     async function playAboutModeAudio() {
-        return playAudio(getAboutAudio())
+        return speak('Sobre', 'status')
     }
 
     async function playFreeModeInstructionsAudio() {
-        return playAudio(getFreeModeInstructionsAudio())
+        return speak(freeModeInstructionsPortuguese, 'instruction')
     }
 
     async function playChallengeModeInstructionsAudio() {
-        return playAudio(getChallengeModeInstructionsAudio())
+        return speak(challengeModeInstructionsPortuguese, 'instruction')
     }
 
     async function playHowToAccessInstructionsAudio(onEnded: () => void) {
-        return playAudio(getHowToAccessInstructionsAudio(), onEnded)
+        return speak(
+            'Pressione I para ouvir as instruções.',
+            'instruction',
+            onEnded,
+        )
     }
 
     // Cell players
     async function playCellAudio(cell: Cell) {
-        return playAudio(getCellAudio(cell))
+        return speak(
+            cell === Cell.C0 ? 'espaço' : cellToString(cell),
+            'reading',
+        )
     }
 
     async function playOutputMuted() {
-        return playAudio(getOutputMutedAudio())
+        return speak('Leitura falada desativada', 'status')
     }
 
     async function playOutputUnmuted() {
-        return playAudio(getOutputUnmutedAudio())
+        return speak('Leitura falada ativada', 'status')
     }
 
     async function playEnterAudio() {
@@ -86,11 +119,11 @@ export default function AudioProvider({ children }: PropsWithChildren) {
     }
 
     async function playBrailleViewAudio() {
-        return playAudio(getBrailleViewAudio())
+        return speak('Visualização em Braille', 'status')
     }
 
     async function playInkViewAudio() {
-        return playAudio(getInkViewAudio())
+        return speak('Visualização a tinta', 'status')
     }
 
     // Keyboard players
@@ -99,31 +132,31 @@ export default function AudioProvider({ children }: PropsWithChildren) {
     }
 
     async function playKeyboardMuted() {
-        return playAudio(getKeyboardMutedAudio())
+        return speak('Sons da máquina desativados', 'status')
     }
 
     async function playKeyboardUnmuted() {
-        return playAudio(getKeyboardUnmutedAudio())
+        return speak('Sons da máquina ativados', 'status')
     }
 
     // Challenge players
-    async function playWordAudio(source: string) {
-        return playAudio(getWordAudio(source))
+    async function playWordAudio(word: string) {
+        return speak(word, 'reading')
     }
 
     async function playRightAnswer(onEnded: () => void) {
-        return playAudio(getRightAnswerAudio(), onEnded)
+        return speak('Resposta correta', 'result', onEnded)
     }
 
     async function playWrongAnswer() {
-        return playAudio(getWrongAnswerAudio())
+        return speak('Resposta incorreta', 'result')
     }
 
     async function playAudio(audio: HTMLAudioElement, onEnded = () => {}) {
         await stopCurrentAudio()
         try {
             await audio.play()
-            setCurrentPlaying(audio)
+            currentPlaying.current = audio
             audio.onended = onEnded
         } catch (error) {
             console.error(error)
@@ -131,10 +164,16 @@ export default function AudioProvider({ children }: PropsWithChildren) {
     }
 
     async function stopCurrentAudio() {
-        if (currentPlaying) {
-            currentPlaying.pause()
-            currentPlaying.currentTime = 0
+        if (currentPlaying.current) {
+            currentPlaying.current.pause()
+            currentPlaying.current.currentTime = 0
+            currentPlaying.current = null
         }
+    }
+
+    function stopAllAudio() {
+        speechOutput?.cancel()
+        void stopCurrentAudio()
     }
 
     const playerFunctions = {
@@ -164,6 +203,7 @@ export default function AudioProvider({ children }: PropsWithChildren) {
         playWordAudio,
         playRightAnswer,
         playWrongAnswer,
+        stopAllAudio,
     }
 
     return (
@@ -173,196 +213,8 @@ export default function AudioProvider({ children }: PropsWithChildren) {
     )
 }
 
-// Menu audio loaders
-function getMainMenuAudio() {
-    return new Audio(
-        'assets/audio/views/menu/menu-principal-da-maquina-den-braille.mp3',
-    )
-}
-
-function getFreeModeAudio() {
-    return new Audio('assets/audio/views/menu/modo-livre.mp3')
-}
-
-function getChallengeModeAudio() {
-    return new Audio('assets/audio/views/menu/modo-desafio.mp3')
-}
-
-function getAboutAudio() {
-    return new Audio('assets/audio/views/menu/sobre.mp3')
-}
-
-function getFreeModeInstructionsAudio() {
-    return new Audio('assets/audio/views/free/instrucoes-modo-livre.mp3')
-}
-
-function getChallengeModeInstructionsAudio() {
-    return new Audio('assets/audio/views/challenge/instrucoes-modo-desafio.mp3')
-}
-
-function getHowToAccessInstructionsAudio() {
-    return new Audio('assets/audio/views/pressione-i-para-instrucoes.mp3')
-}
-
-// Cell audio loaders
-function getCellAudio(cell: Cell) {
-    switch (cell) {
-        case Cell.C0:
-            return new Audio('assets/audio/cells/espaco.mp3')
-
-        case Cell.C1:
-            return new Audio('assets/audio/cells/a.mp3')
-        case Cell.C12:
-            return new Audio('assets/audio/cells/b.mp3')
-        case Cell.C14:
-            return new Audio('assets/audio/cells/c.mp3')
-        case Cell.C145:
-            return new Audio('assets/audio/cells/d.mp3')
-        case Cell.C15:
-            return new Audio('assets/audio/cells/e.mp3')
-        case Cell.C124:
-            return new Audio('assets/audio/cells/f.mp3')
-        case Cell.C1245:
-            return new Audio('assets/audio/cells/g.mp3')
-        case Cell.C125:
-            return new Audio('assets/audio/cells/h.mp3')
-        case Cell.C24:
-            return new Audio('assets/audio/cells/i.mp3')
-        case Cell.C245:
-            return new Audio('assets/audio/cells/j.mp3')
-
-        case Cell.C13:
-            return new Audio('assets/audio/cells/k.mp3')
-        case Cell.C123:
-            return new Audio('assets/audio/cells/l.mp3')
-        case Cell.C134:
-            return new Audio('assets/audio/cells/m.mp3')
-        case Cell.C1345:
-            return new Audio('assets/audio/cells/n.mp3')
-        case Cell.C135:
-            return new Audio('assets/audio/cells/o.mp3')
-        case Cell.C1234:
-            return new Audio('assets/audio/cells/p.mp3')
-        case Cell.C12345:
-            return new Audio('assets/audio/cells/q.mp3')
-        case Cell.C1235:
-            return new Audio('assets/audio/cells/r.mp3')
-        case Cell.C234:
-            return new Audio('assets/audio/cells/s.mp3')
-        case Cell.C2345:
-            return new Audio('assets/audio/cells/t.mp3')
-
-        case Cell.C136:
-            return new Audio('assets/audio/cells/u.mp3')
-        case Cell.C1236:
-            return new Audio('assets/audio/cells/v.mp3')
-        case Cell.C1346:
-            return new Audio('assets/audio/cells/x.mp3')
-        case Cell.C13456:
-            return new Audio('assets/audio/cells/y.mp3')
-        case Cell.C1356:
-            return new Audio('assets/audio/cells/z.mp3')
-        case Cell.C12346:
-            return new Audio('assets/audio/cells/cedilha.mp3')
-        case Cell.C123456:
-            return new Audio('assets/audio/cells/e-agudo.mp3')
-        case Cell.C12356:
-            return new Audio('assets/audio/cells/a-agudo.mp3')
-        case Cell.C2346:
-            return new Audio('assets/audio/cells/e-crase.mp3')
-        case Cell.C23456:
-            return new Audio('assets/audio/cells/u-agudo.mp3')
-
-        case Cell.C16:
-            return new Audio('assets/audio/cells/a-circunflexo.mp3')
-        case Cell.C126:
-            return new Audio('assets/audio/cells/e-circunflexo.mp3')
-        case Cell.C146:
-            return new Audio('assets/audio/cells/i-crase.mp3')
-        case Cell.C1456:
-            return new Audio('assets/audio/cells/o-circunflexo.mp3')
-        case Cell.C156:
-            return new Audio('assets/audio/cells/u-crase.mp3')
-        case Cell.C1246:
-            return new Audio('assets/audio/cells/a-crase.mp3')
-        case Cell.C12456:
-            return new Audio('assets/audio/cells/n-til.mp3')
-        case Cell.C1256:
-            return new Audio('assets/audio/cells/u-trema.mp3')
-        case Cell.C246:
-            return new Audio('assets/audio/cells/o-til.mp3')
-        case Cell.C2456:
-            return new Audio('assets/audio/cells/w.mp3')
-
-        case Cell.C2:
-            return new Audio('assets/audio/cells/virgula.mp3')
-        case Cell.C23:
-            return new Audio('assets/audio/cells/ponto-e-virgula.mp3')
-        case Cell.C25:
-            return new Audio('assets/audio/cells/dois-pontos.mp3')
-        case Cell.C256:
-            return new Audio('assets/audio/cells/divisao.mp3')
-        case Cell.C26:
-            return new Audio('assets/audio/cells/interrogacao.mp3')
-        case Cell.C235:
-            return new Audio('assets/audio/cells/exclamacao.mp3')
-        case Cell.C2356:
-            return new Audio('assets/audio/cells/igual.mp3')
-        case Cell.C236:
-            return new Audio('assets/audio/cells/aspa.mp3')
-        case Cell.C35:
-            return new Audio('assets/audio/cells/asterisco.mp3')
-        case Cell.C356:
-            return new Audio('assets/audio/cells/grau.mp3')
-
-        case Cell.C34:
-            return new Audio('assets/audio/cells/i-agudo.mp3')
-        case Cell.C345:
-            return new Audio('assets/audio/cells/a-til.mp3')
-        case Cell.C346:
-            return new Audio('assets/audio/cells/o-agudo.mp3')
-        case Cell.C3456:
-            return new Audio('assets/audio/cells/sinal-de-numero.mp3')
-        case Cell.C3:
-            return new Audio('assets/audio/cells/ponto.mp3')
-        case Cell.C36:
-            return new Audio('assets/audio/cells/hifen.mp3')
-
-        case Cell.C4:
-            return new Audio('assets/audio/cells/circunflexo.mp3')
-        case Cell.C45:
-            return new Audio('assets/audio/cells/sinal-de-negacao.mp3')
-        case Cell.C456:
-            return new Audio('assets/audio/cells/barra.mp3')
-        case Cell.C5:
-            return new Audio('assets/audio/cells/sinal-de-delimitador.mp3')
-        case Cell.C46:
-            return new Audio('assets/audio/cells/sinal-de-maiusculo.mp3')
-        case Cell.C56:
-            return new Audio('assets/audio/cells/cifrao.mp3')
-        case Cell.C6:
-            return new Audio('assets/audio/cells/apostrofo.mp3')
-    }
-}
-
-function getOutputMutedAudio() {
-    return new Audio('assets/audio/actions/conversor-mutado.mp3')
-}
-
-function getOutputUnmutedAudio() {
-    return new Audio('assets/audio/actions/conversor-desmutado.mp3')
-}
-
 function getEnterAudio() {
     return new Audio('assets/audio/keys/enter.mp3')
-}
-
-function getBrailleViewAudio() {
-    return new Audio('assets/audio/actions/visualizacao-em-braille.mp3')
-}
-
-function getInkViewAudio() {
-    return new Audio('assets/audio/actions/visualizacao-a-tinta.mp3')
 }
 
 // Keyboard audio loaders
@@ -376,25 +228,4 @@ function getRandomKeyboardAudio() {
 
     const index = Math.floor(Math.random() * audioPaths.length)
     return new Audio(audioPaths[index])
-}
-
-function getKeyboardMutedAudio() {
-    return new Audio('assets/audio/actions/teclado-mutado.mp3')
-}
-
-function getKeyboardUnmutedAudio() {
-    return new Audio('assets/audio/actions/teclado-desmutado.mp3')
-}
-
-// Challenge audio loader
-function getWordAudio(source: string) {
-    return new Audio(source)
-}
-
-function getRightAnswerAudio() {
-    return new Audio('assets/audio/views/challenge/certa-resposta.mp3')
-}
-
-function getWrongAnswerAudio() {
-    return new Audio('assets/audio/views/challenge/resposta-errada.mp3')
 }

--- a/src/tests/Journeys.test.tsx
+++ b/src/tests/Journeys.test.tsx
@@ -1,5 +1,5 @@
 // Temporary legacy journey tests; remove them with the legacy implementation.
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
@@ -19,6 +19,31 @@ class AudioStub {
     constructor(public src: string) {
         AudioStub.instances.push(this)
     }
+}
+
+class UtteranceStub {
+    lang = ''
+    rate = 1
+    pitch = 1
+    volume = 1
+    onend?: () => void
+    onerror?: (event: { error?: string }) => void
+
+    constructor(public text: string) {}
+}
+
+const speechSynthesisStub = {
+    getVoices: vi.fn(() => [
+        {
+            name: 'Português',
+            lang: 'pt-BR',
+            default: true,
+            localService: true,
+        },
+    ]),
+    speak: vi.fn((utterance: UtteranceStub) => utterance.onend?.()),
+    cancel: vi.fn(),
+    addEventListener: vi.fn(),
 }
 
 function renderWithAudio(component: React.ReactElement) {
@@ -77,13 +102,17 @@ function audioEndingWith(path: string) {
 beforeEach(() => {
     AudioStub.instances = []
     globalThis.Audio = AudioStub as unknown as typeof Audio
+    vi.stubGlobal('SpeechSynthesisUtterance', UtteranceStub)
+    vi.stubGlobal('speechSynthesis', speechSynthesisStub)
+    speechSynthesisStub.speak.mockClear()
+    speechSynthesisStub.cancel.mockClear()
 })
 
 afterEach(() => {
     vi.restoreAllMocks()
 })
 
-test('home offers free and challenge modes through focusable links with audio', async () => {
+test('home speaks menu labels without recorded speech files', async () => {
     renderWithAudio(<Home />)
 
     const freeMode = screen.getByRole('link', { name: 'Modo livre' })
@@ -96,9 +125,17 @@ test('home offers free and challenge modes through focusable links with audio', 
     fireEvent.focus(challengeMode)
 
     await waitFor(() => {
-        expect(audioEndingWith('modo-livre.mp3')?.play).toHaveBeenCalled()
-        expect(audioEndingWith('modo-desafio.mp3')?.play).toHaveBeenCalled()
+        expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'Modo livre' }),
+        )
     })
+    await waitFor(() => {
+        expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'Modo desafio' }),
+        )
+    })
+    expect(audioEndingWith('modo-livre.mp3')).toBeUndefined()
+    expect(audioEndingWith('modo-desafio.mp3')).toBeUndefined()
 })
 
 test('challenge mode reports errors and advances after a correct chord response', async () => {
@@ -117,28 +154,36 @@ test('challenge mode reports errors and advances after a correct chord response'
     press(typewriter, 'Enter')
 
     await waitFor(() => {
-        expect(audioEndingWith('resposta-errada.mp3')?.play).toHaveBeenCalled()
-        expect(
-            audioEndingWith(
-                `words/${word.replace('é', 'e').replace('ã', 'a')}.mp3`,
-            )?.play,
-        ).toHaveBeenCalled()
+        expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'Resposta incorreta' }),
+        )
     })
+    expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+        expect.objectContaining({
+            text: expect.stringContaining('No modo desafio'),
+        }),
+    )
+    expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+        expect.objectContaining({ text: word }),
+    )
+    expect(audioEndingWith('instrucoes-modo-desafio.mp3')).toBeUndefined()
+    expect(
+        audioEndingWith(
+            `words/${word.replace('é', 'e').replace('ã', 'a')}.mp3`,
+        ),
+    ).toBeUndefined()
 
     for (const letter of word) {
         chord(typewriter, letterChords[letter as keyof typeof letterChords])
     }
-    press(typewriter, 'Enter')
-
-    const successAudio = await waitFor(() => {
-        const audio = audioEndingWith('certa-resposta.mp3')
-        expect(audio?.play).toHaveBeenCalled()
-        return audio as AudioStub
-    })
-
     const selectionsBeforeSuccess = random.mock.calls.length
     random.mockReturnValue(0.1)
-    await act(async () => successAudio.onended?.())
+    press(typewriter, 'Enter')
+    await waitFor(() => {
+        expect(speechSynthesisStub.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'Resposta correta' }),
+        )
+    })
 
     await waitFor(() =>
         expect(random.mock.calls.length).toBeGreaterThan(

--- a/src/ui/public.ts
+++ b/src/ui/public.ts
@@ -1,5 +1,8 @@
 export { default as FreeTypingSession } from './session/FreeTypingSession'
 export type { FreeTypingSessionProps } from './session/FreeTypingSession'
-export type { LegacyFreeModeAction } from './session/legacyFreeModeKeyboard'
+export {
+    legacyFreeModeActionForKey,
+    type LegacyFreeModeAction,
+} from './session/legacyFreeModeKeyboard'
 export { default as AccessibleFeedback } from './feedback/AccessibleFeedback'
 export type { AccessibleFeedbackProps } from './feedback/AccessibleFeedback'

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -227,7 +227,7 @@ export default function FreeTypingSession({
                     <strong>(t)</strong> Ver texto a tinta ou em Braille
                 </div>
                 <div>
-                    <strong>(o)</strong> Liga/desliga leitura falada
+                    <strong>(O — letra)</strong> Liga/desliga leitura falada
                 </div>
                 <div>
                     <strong>(m)</strong> Liga/desliga sons da máquina

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -83,7 +83,11 @@ export type FreeTypingSessionProps = Readonly<{
     dispatch: (input: SessionInput) => void
     keyboardBindings: WebKeyboardBindings
     presentationPreferences: SimulatorPreferences['presentation'] &
-        Readonly<{ keyboardAudioEnabled: boolean }>
+        Readonly<{
+            keyboardAudioEnabled: boolean
+            speechEnabled: boolean
+            soundsEnabled: boolean
+        }>
     onPresentationAction: (action: LegacyFreeModeAction) => void
     onMachineKeyPressed: () => void
 }>
@@ -193,7 +197,7 @@ export default function FreeTypingSession({
             onKeyUp={(event) => handleKeyboardEvent(event, 'release')}
         >
             <div className="fs-1">MODO LIVRE</div>
-            <div role="status" aria-live="polite">
+            <div role="status" aria-label="Estado da sessão" aria-live="polite">
                 {snapshot.capture.status === 'active'
                     ? 'Captura ativa'
                     : 'Captura inativa'}{' '}
@@ -201,9 +205,20 @@ export default function FreeTypingSession({
                 coluna {snapshot.document.reviewPosition.column + 1}
             </div>
             <p>
-                A leitura falada começa desligada. Pressione O para ativar ou
-                silenciar, R para repetir e P para interromper.
+                A leitura falada começa desligada por padrão. Pressione O para
+                ativar ou silenciar, R para repetir e P para interromper.
             </p>
+            <div aria-live="polite">
+                Leitura falada:{' '}
+                {presentationPreferences.speechEnabled
+                    ? 'ativada'
+                    : 'desativada'}
+                . Sons da máquina:{' '}
+                {presentationPreferences.soundsEnabled
+                    ? 'ativados'
+                    : 'desativados'}
+                .
+            </div>
             <div className="d-flex justify-content-center w-100 fs-5 gap-3 mb-3">
                 <div>
                     <strong>(i)</strong> Instruções

--- a/src/ui/session/FreeTypingSession.tsx
+++ b/src/ui/session/FreeTypingSession.tsx
@@ -82,7 +82,8 @@ export type FreeTypingSessionProps = Readonly<{
     snapshot: TypingSessionSnapshot
     dispatch: (input: SessionInput) => void
     keyboardBindings: WebKeyboardBindings
-    presentationPreferences: SimulatorPreferences['presentation']
+    presentationPreferences: SimulatorPreferences['presentation'] &
+        Readonly<{ keyboardAudioEnabled: boolean }>
     onPresentationAction: (action: LegacyFreeModeAction) => void
     onMachineKeyPressed: () => void
 }>
@@ -199,6 +200,10 @@ export default function FreeTypingSession({
                 — revisão: linha {snapshot.document.reviewPosition.row + 1},
                 coluna {snapshot.document.reviewPosition.column + 1}
             </div>
+            <p>
+                A leitura falada começa desligada. Pressione O para ativar ou
+                silenciar, R para repetir e P para interromper.
+            </p>
             <div className="d-flex justify-content-center w-100 fs-5 gap-3 mb-3">
                 <div>
                     <strong>(i)</strong> Instruções
@@ -207,10 +212,16 @@ export default function FreeTypingSession({
                     <strong>(t)</strong> Ver texto a tinta ou em Braille
                 </div>
                 <div>
-                    <strong>(o)</strong> Liga/desliga áudio do conversor
+                    <strong>(o)</strong> Liga/desliga leitura falada
                 </div>
                 <div>
-                    <strong>(m)</strong> Liga/desliga áudio do teclado
+                    <strong>(m)</strong> Liga/desliga sons da máquina
+                </div>
+                <div>
+                    <strong>(r)</strong> Repetir última fala
+                </div>
+                <div>
+                    <strong>(p)</strong> Interromper fala e sons
                 </div>
                 <div>
                     <strong>(Esc)</strong> Pausa/retoma a captura

--- a/src/ui/session/legacyFreeModeKeyboard.ts
+++ b/src/ui/session/legacyFreeModeKeyboard.ts
@@ -2,16 +2,16 @@
 export type LegacyFreeModeAction =
     | 'instructions-requested'
     | 'view-toggled'
-    | 'output-audio-toggled'
-    | 'keyboard-audio-toggled'
+    | 'speech-toggled'
+    | 'sounds-toggled'
     | 'speech-stopped'
     | 'speech-repeated'
 
 const actionByCode = new Map<string, LegacyFreeModeAction>([
     ['KeyI', 'instructions-requested'],
     ['KeyT', 'view-toggled'],
-    ['KeyO', 'output-audio-toggled'],
-    ['KeyM', 'keyboard-audio-toggled'],
+    ['KeyO', 'speech-toggled'],
+    ['KeyM', 'sounds-toggled'],
     ['KeyP', 'speech-stopped'],
     ['KeyR', 'speech-repeated'],
 ])

--- a/src/ui/session/legacyFreeModeKeyboard.ts
+++ b/src/ui/session/legacyFreeModeKeyboard.ts
@@ -4,12 +4,16 @@ export type LegacyFreeModeAction =
     | 'view-toggled'
     | 'output-audio-toggled'
     | 'keyboard-audio-toggled'
+    | 'speech-stopped'
+    | 'speech-repeated'
 
 const actionByCode = new Map<string, LegacyFreeModeAction>([
     ['KeyI', 'instructions-requested'],
     ['KeyT', 'view-toggled'],
     ['KeyO', 'output-audio-toggled'],
     ['KeyM', 'keyboard-audio-toggled'],
+    ['KeyP', 'speech-stopped'],
+    ['KeyR', 'speech-repeated'],
 ])
 
 /** Converts a plain keyboard event into a legacy presentation action. */

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -10,7 +10,7 @@ export default function Home() {
         playMainMenuAudio,
         playFreeModeAudio,
         playChallengeModeAudio,
-        playAboutModeAudio,
+        stopAllAudio,
     } = useAudioContext()
 
     function handleBtnFreeModeFocused() {
@@ -21,13 +21,10 @@ export default function Home() {
         playChallengeModeAudio()
     }
 
-    function handleBtnAboutFocused() {
-        playAboutModeAudio()
-    }
-
     useEffect(() => {
         playMainMenuAudio()
-    }, [])
+        return stopAllAudio
+    }, [playMainMenuAudio, stopAllAudio])
 
     return (
         <>

--- a/src/views/modes/Challenge.tsx
+++ b/src/views/modes/Challenge.tsx
@@ -9,7 +9,6 @@ import { useAudioContext } from '../../providers/AudioProvider'
 
 export interface RandomWord {
     word: string
-    audioSrc: string
     cells: List<Cell>
 }
 
@@ -20,10 +19,12 @@ export default function Challenge() {
         playWordAudio,
         playRightAnswer,
         playWrongAnswer,
+        stopAllAudio,
     } = useAudioContext()
 
     const output = useRef<HTMLTextAreaElement>(null)
-    const [randomWord, setRandomWord] = useState<RandomWord>()
+    const [randomWord, setRandomWord] = useState<RandomWord>(getRandomWord)
+    const initialWord = useRef(randomWord)
 
     function getNextRandomWord() {
         console.info('Get next random word')
@@ -31,10 +32,8 @@ export default function Challenge() {
     }
 
     function playRandomWordAudio() {
-        if (randomWord) {
-            console.info('Play word audio: ' + randomWord.word)
-            playWordAudio(randomWord?.audioSrc)
-        }
+        console.info('Play word audio: ' + randomWord.word)
+        playWordAudio(randomWord.word)
     }
 
     function verifyAnswer(outputValue: string) {
@@ -64,9 +63,11 @@ export default function Challenge() {
     }
 
     useEffect(() => {
-        getNextRandomWord()
-        playHowToAccessInstructionsAudio(playRandomWordAudio)
-    }, [])
+        playHowToAccessInstructionsAudio(() =>
+            playWordAudio(initialWord.current.word),
+        )
+        return stopAllAudio
+    }, [playHowToAccessInstructionsAudio, playWordAudio, stopAllAudio])
 
     return (
         <>
@@ -92,7 +93,6 @@ const wordsMap = Map([
     [
         'casa',
         {
-            audioSrc: 'assets/audio/views/challenge/words/casa.mp3',
             cells: List([Cell.C14, Cell.C1, Cell.C234, Cell.C1]),
         },
     ],
@@ -100,7 +100,6 @@ const wordsMap = Map([
     [
         'amor',
         {
-            audioSrc: 'assets/audio/views/challenge/words/amor.mp3',
             cells: List([Cell.C1, Cell.C134, Cell.C135, Cell.C1235]),
         },
     ],
@@ -108,7 +107,6 @@ const wordsMap = Map([
     [
         'feliz',
         {
-            audioSrc: 'assets/audio/views/challenge/words/feliz.mp3',
             cells: List([Cell.C124, Cell.C15, Cell.C123, Cell.C24, Cell.C1356]),
         },
     ],
@@ -116,7 +114,6 @@ const wordsMap = Map([
     [
         'livro',
         {
-            audioSrc: 'assets/audio/views/challenge/words/livro.mp3',
             cells: List([
                 Cell.C123,
                 Cell.C24,
@@ -130,7 +127,6 @@ const wordsMap = Map([
     [
         'braille',
         {
-            audioSrc: 'assets/audio/views/challenge/words/braille.mp3',
             cells: List([
                 Cell.C12,
                 Cell.C1235,
@@ -146,7 +142,6 @@ const wordsMap = Map([
     [
         'flor',
         {
-            audioSrc: 'assets/audio/views/challenge/words/flor.mp3',
             cells: List([Cell.C124, Cell.C123, Cell.C135, Cell.C1235]),
         },
     ],
@@ -154,7 +149,6 @@ const wordsMap = Map([
     [
         'escola',
         {
-            audioSrc: 'assets/audio/views/challenge/words/escola.mp3',
             cells: List([
                 Cell.C15,
                 Cell.C234,
@@ -169,7 +163,6 @@ const wordsMap = Map([
     [
         'brasil',
         {
-            audioSrc: 'assets/audio/views/challenge/words/brasil.mp3',
             cells: List([
                 Cell.C12,
                 Cell.C1235,
@@ -184,7 +177,6 @@ const wordsMap = Map([
     [
         'café',
         {
-            audioSrc: 'assets/audio/views/challenge/words/cafe.mp3',
             cells: List([Cell.C14, Cell.C1, Cell.C124, Cell.C123456]),
         },
     ],
@@ -192,7 +184,6 @@ const wordsMap = Map([
     [
         'natureza',
         {
-            audioSrc: 'assets/audio/views/challenge/words/natureza.mp3',
             cells: List([
                 Cell.C1345,
                 Cell.C1,
@@ -209,7 +200,6 @@ const wordsMap = Map([
     [
         'sol',
         {
-            audioSrc: 'assets/audio/views/challenge/words/sol.mp3',
             cells: List([Cell.C234, Cell.C135, Cell.C123]),
         },
     ],
@@ -217,7 +207,6 @@ const wordsMap = Map([
     [
         'estrela',
         {
-            audioSrc: 'assets/audio/views/challenge/words/estrela.mp3',
             cells: List([
                 Cell.C15,
                 Cell.C234,
@@ -233,7 +222,6 @@ const wordsMap = Map([
     [
         'computador',
         {
-            audioSrc: 'assets/audio/views/challenge/words/computador.mp3',
             cells: List([
                 Cell.C14,
                 Cell.C135,
@@ -252,7 +240,6 @@ const wordsMap = Map([
     [
         'inclusão',
         {
-            audioSrc: 'assets/audio/views/challenge/words/inclusao.mp3',
             cells: List([
                 Cell.C24,
                 Cell.C1345,
@@ -269,7 +256,6 @@ const wordsMap = Map([
     [
         'aventura',
         {
-            audioSrc: 'assets/audio/views/challenge/words/aventura.mp3',
             cells: List([
                 Cell.C1,
                 Cell.C1236,
@@ -293,7 +279,6 @@ function getRandomWord() {
 
     const obj = {
         word: word,
-        audioSrc: entry?.audioSrc as string,
         cells: entry?.cells as List<Cell>,
     }
 

--- a/tests/contracts/automatic-reading.test.ts
+++ b/tests/contracts/automatic-reading.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+
+import type { BrailleInterpretation } from '../../src/braille/public'
+import { resolveAutomaticReading } from '../../src/feedback/public'
+
+const interpretation = (text: string): BrailleInterpretation => ({
+    profile: {
+        id: 'portuguese-braille-2018',
+        language: 'pt-BR',
+        edition: '2018',
+    },
+    lines: [
+        {
+            segments: [...text].map((symbol, column) => ({
+                status: 'interpreted' as const,
+                role: 'symbol' as const,
+                source: [{ sheet: 0, row: 0, column }],
+                text: symbol,
+            })),
+        },
+    ],
+})
+
+describe('automatic production reading', () => {
+    test('reads the newly interpreted symbol after cell production', () => {
+        expect(
+            resolveAutomaticReading(interpretation('a'), interpretation('ab'), [
+                {
+                    type: 'operation-produced',
+                    operation: {
+                        type: 'confirm-cell',
+                        cell: { dots: [1, 2] },
+                    },
+                },
+            ]),
+        ).toBe('b')
+    })
+
+    test('names an explicit blank cell and ignores editing operations', () => {
+        expect(
+            resolveAutomaticReading(interpretation('a'), interpretation('a '), [
+                { type: 'operation-produced', operation: { type: 'space' } },
+            ]),
+        ).toBe('espaço')
+        expect(
+            resolveAutomaticReading(interpretation('ab'), interpretation('a'), [
+                {
+                    type: 'operation-produced',
+                    operation: { type: 'backspace' },
+                },
+            ]),
+        ).toBeUndefined()
+    })
+})

--- a/tests/contracts/automatic-reading.test.ts
+++ b/tests/contracts/automatic-reading.test.ts
@@ -36,6 +36,37 @@ describe('automatic production reading', () => {
         ).toBe('b')
     })
 
+    test.each([
+        ['á', 'a agudo'],
+        ['à', 'a grave'],
+        ['â', 'a circunflexo'],
+        ['ã', 'a til'],
+        ['ç', 'c cedilha'],
+        ['é', 'e agudo'],
+        ['ê', 'e circunflexo'],
+        ['í', 'i agudo'],
+        ['ó', 'o agudo'],
+        ['ô', 'o circunflexo'],
+        ['õ', 'o til'],
+        ['ú', 'u agudo'],
+    ])('names the Portuguese character %s as %s', (symbol, spokenName) => {
+        expect(
+            resolveAutomaticReading(
+                interpretation(''),
+                interpretation(symbol),
+                [
+                    {
+                        type: 'operation-produced',
+                        operation: {
+                            type: 'confirm-cell',
+                            cell: { dots: [1] },
+                        },
+                    },
+                ],
+            ),
+        ).toBe(spokenName)
+    })
+
     test('names an explicit blank cell and ignores editing operations', () => {
         expect(
             resolveAutomaticReading(interpretation('a'), interpretation('a '), [

--- a/tests/contracts/multimodal-feedback.test.ts
+++ b/tests/contracts/multimodal-feedback.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+    createMultimodalFeedbackController,
+    type MessageFeedbackPlan,
+    type SoundOutput,
+    type SpeechOutput,
+} from '../../src/feedback/public'
+import { createDefaultSimulatorPreferences } from '../../src/preferences/public'
+
+const plan: MessageFeedbackPlan = Object.freeze({
+    disposition: 'message',
+    message: Object.freeze({
+        id: 'capture-activated',
+        parameters: Object.freeze({}),
+    }),
+    priority: 'normal',
+    repetition: 'replace',
+    interruption: 'all',
+    channels: Object.freeze({ visual: true, accessible: 'polite' }),
+})
+
+const setup = (speechEnabled = true, soundsEnabled = true) => {
+    const speech: SpeechOutput = {
+        speak: vi.fn().mockResolvedValue('completed'),
+        cancel: vi.fn(),
+    }
+    const sound: SoundOutput = {
+        play: vi.fn().mockResolvedValue('completed'),
+        cancel: vi.fn(),
+    }
+    const defaults = createDefaultSimulatorPreferences()
+    const preferences = {
+        ...defaults.feedback,
+        speech: { ...defaults.feedback.speech, enabled: speechEnabled },
+        sounds: { enabled: soundsEnabled },
+    }
+    const unavailable = vi.fn()
+    const instructionFallback = vi.fn()
+    const accessibleFallback = vi.fn()
+    const controller = createMultimodalFeedbackController({
+        speechOutput: speech,
+        soundOutput: sound,
+        getPreferences: () => preferences,
+        onSpeechUnavailable: unavailable,
+        presentInstructionFallback: instructionFallback,
+        presentAccessibleFallback: accessibleFallback,
+    })
+    return {
+        controller,
+        speech,
+        sound,
+        unavailable,
+        instructionFallback,
+        accessibleFallback,
+    }
+}
+
+describe('multimodal feedback controller', () => {
+    it('delivers canonical messages and applies interruption policy', async () => {
+        const { controller, speech } = setup()
+
+        const presentationPlans = controller.deliverPlans([plan])
+        await Promise.resolve()
+
+        expect(speech.cancel).toHaveBeenCalledOnce()
+        expect(presentationPlans[0]?.channels.accessible).toBe('off')
+        expect(speech.speak).toHaveBeenCalledWith(
+            expect.objectContaining({
+                text: 'Captura de acordes ativada.',
+                purpose: 'status',
+                locale: 'pt-BR',
+            }),
+        )
+    })
+
+    it('owns instructions, repetition, stopping, and optional sounds', async () => {
+        const { controller, speech, sound } = setup()
+
+        controller.requestInstructions()
+        await Promise.resolve()
+        controller.repeatSpeech()
+        controller.playMachineKey()
+        controller.applyPreferences({
+            ...createDefaultSimulatorPreferences().feedback,
+            speech: {
+                ...createDefaultSimulatorPreferences().feedback.speech,
+                enabled: true,
+            },
+            sounds: { enabled: false },
+        })
+        controller.stop()
+
+        expect(speech.speak).toHaveBeenCalledTimes(2)
+        expect(sound.play).toHaveBeenCalledWith({ type: 'machine-key' })
+        expect(speech.cancel).toHaveBeenCalledOnce()
+        expect(sound.cancel).toHaveBeenCalledTimes(2)
+    })
+
+    it('keeps every operation safe when audio is disabled or unavailable', async () => {
+        const disabled = setup(false, false)
+        const disabledPlans = disabled.controller.deliverPlans([plan])
+        disabled.controller.requestInstructions()
+        disabled.controller.repeatSpeech()
+        disabled.controller.playMachineKey()
+        expect(disabled.speech.speak).not.toHaveBeenCalled()
+        expect(disabled.sound.play).not.toHaveBeenCalled()
+        expect(disabledPlans[0]?.channels.accessible).toBe('polite')
+
+        const unavailable = setup()
+        const controller = createMultimodalFeedbackController({
+            speechOutput: undefined,
+            soundOutput: unavailable.sound,
+            getPreferences: () => ({
+                ...createDefaultSimulatorPreferences().feedback,
+                speech: {
+                    ...createDefaultSimulatorPreferences().feedback.speech,
+                    enabled: true,
+                },
+            }),
+            onSpeechUnavailable: unavailable.unavailable,
+            presentInstructionFallback: unavailable.instructionFallback,
+            presentAccessibleFallback: unavailable.accessibleFallback,
+        })
+        const unavailablePlans = controller.deliverPlans([plan])
+        controller.requestInstructions()
+        expect(unavailable.unavailable).toHaveBeenCalledTimes(2)
+        expect(unavailable.instructionFallback).toHaveBeenCalledOnce()
+        expect(unavailablePlans[0]?.channels.accessible).toBe('polite')
+        expect(unavailable.accessibleFallback).toHaveBeenCalledWith([plan])
+
+        const failedSpeech = setup(true, true)
+        vi.mocked(failedSpeech.speech.speak).mockResolvedValue('failed')
+        const initiallySpoken = failedSpeech.controller.deliverPlans([plan])
+        expect(initiallySpoken[0]?.channels.accessible).toBe('off')
+        await Promise.resolve()
+        expect(failedSpeech.accessibleFallback).toHaveBeenCalledWith([plan])
+
+        expect(disabled.instructionFallback).toHaveBeenCalledOnce()
+
+        const failedSound = setup(false, true)
+        vi.mocked(failedSound.sound.play).mockResolvedValue('failed')
+        failedSound.controller.requestInstructions()
+        await Promise.resolve()
+        expect(failedSound.instructionFallback).toHaveBeenCalledOnce()
+    })
+})

--- a/tests/contracts/multimodal-feedback.test.ts
+++ b/tests/contracts/multimodal-feedback.test.ts
@@ -81,6 +81,7 @@ describe('multimodal feedback controller', () => {
         await Promise.resolve()
         controller.repeatSpeech()
         controller.playMachineKey()
+        controller.readProduction('a')
         controller.applyPreferences({
             ...createDefaultSimulatorPreferences().feedback,
             speech: {
@@ -91,7 +92,10 @@ describe('multimodal feedback controller', () => {
         })
         controller.stop()
 
-        expect(speech.speak).toHaveBeenCalledTimes(2)
+        expect(speech.speak).toHaveBeenCalledTimes(3)
+        expect(speech.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ text: 'a', purpose: 'reading' }),
+        )
         expect(sound.play).toHaveBeenCalledWith({ type: 'machine-key' })
         expect(speech.cancel).toHaveBeenCalledOnce()
         expect(sound.cancel).toHaveBeenCalledTimes(2)
@@ -103,7 +107,10 @@ describe('multimodal feedback controller', () => {
         disabled.controller.requestInstructions()
         disabled.controller.repeatSpeech()
         disabled.controller.playMachineKey()
-        expect(disabled.speech.speak).not.toHaveBeenCalled()
+        expect(disabled.speech.speak).toHaveBeenCalledTimes(2)
+        expect(disabled.speech.speak).toHaveBeenCalledWith(
+            expect.objectContaining({ purpose: 'instruction' }),
+        )
         expect(disabled.sound.play).not.toHaveBeenCalled()
         expect(disabledPlans[0]?.channels.accessible).toBe('polite')
 
@@ -136,12 +143,10 @@ describe('multimodal feedback controller', () => {
         await Promise.resolve()
         expect(failedSpeech.accessibleFallback).toHaveBeenCalledWith([plan])
 
-        expect(disabled.instructionFallback).toHaveBeenCalledOnce()
-
-        const failedSound = setup(false, true)
-        vi.mocked(failedSound.sound.play).mockResolvedValue('failed')
-        failedSound.controller.requestInstructions()
+        const failedInstruction = setup(false, true)
+        vi.mocked(failedInstruction.speech.speak).mockResolvedValue('failed')
+        failedInstruction.controller.requestInstructions()
         await Promise.resolve()
-        expect(failedSound.instructionFallback).toHaveBeenCalledOnce()
+        expect(failedInstruction.instructionFallback).toHaveBeenCalledOnce()
     })
 })

--- a/tests/contracts/preferences-storage.test.ts
+++ b/tests/contracts/preferences-storage.test.ts
@@ -30,8 +30,6 @@ describe.each<[string, StorageFactory]>([
             ...createDefaultSimulatorPreferences(),
             presentation: {
                 view: 'ink' as const,
-                outputAudioEnabled: false,
-                keyboardAudioEnabled: true,
             },
         }
 

--- a/tests/contracts/web-sound-output.test.ts
+++ b/tests/contracts/web-sound-output.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { createWebSoundOutput, type WebAudio } from '../../src/feedback/public'
+
+describe('Web sound output', () => {
+    test('resolves semantic cues and exposes completion', async () => {
+        const play = vi.fn().mockResolvedValue(undefined)
+        const audio: WebAudio = {
+            play,
+            pause: vi.fn(),
+            currentTime: 0,
+            onended: null,
+        }
+        const output = createWebSoundOutput(
+            () => audio,
+            () => 0,
+        )
+
+        const completion = output.play({ type: 'machine-key' })
+        audio.onended?.(new Event('ended'))
+
+        await expect(completion).resolves.toBe('completed')
+        expect(play).toHaveBeenCalledOnce()
+    })
+
+    test('cancels the current sound and reports unavailable assets', async () => {
+        const audio: WebAudio = {
+            play: vi.fn().mockResolvedValue(undefined),
+            pause: vi.fn(),
+            currentTime: 4,
+            onended: null,
+        }
+        const output = createWebSoundOutput(
+            () => audio,
+            () => 0,
+        )
+
+        void output.play({ type: 'machine-key' })
+        output.cancel()
+
+        expect(audio.pause).toHaveBeenCalledOnce()
+        expect(audio.currentTime).toBe(0)
+        await expect(
+            output.play({ type: 'editorial', id: 'missing' }),
+        ).resolves.toBe('unavailable')
+    })
+
+    test('reports player creation failure without throwing', async () => {
+        const output = createWebSoundOutput(() => {
+            throw new Error('audio unavailable')
+        })
+
+        await expect(output.play({ type: 'machine-key' })).resolves.toBe(
+            'failed',
+        )
+    })
+})

--- a/tests/contracts/web-sound-output.test.ts
+++ b/tests/contracts/web-sound-output.test.ts
@@ -54,4 +54,20 @@ describe('Web sound output', () => {
             'failed',
         )
     })
+
+    test('replaces and settles a previous overlapping sound', async () => {
+        const audios = [0, 1].map(() => ({
+            play: vi.fn().mockResolvedValue(undefined),
+            pause: vi.fn(),
+            currentTime: 3,
+            onended: null,
+        }))
+        const output = createWebSoundOutput(() => audios.shift()!)
+
+        const first = output.play({ type: 'machine-key' })
+        void output.play({ type: 'machine-key' })
+
+        await expect(first).resolves.toBe('cancelled')
+        expect(audios).toHaveLength(0)
+    })
 })

--- a/tests/contracts/web-speech-output.test.ts
+++ b/tests/contracts/web-speech-output.test.ts
@@ -111,4 +111,46 @@ describe('Web Speech output', () => {
         expect(synthesis.cancel).toHaveBeenCalledOnce()
         return expect(completion).resolves.toBe('cancelled')
     })
+
+    test('refreshes the voice catalog when the platform announces changes', async () => {
+        const portuguese = {
+            name: 'Portuguese',
+            lang: 'pt-BR',
+            default: true,
+            localService: true,
+        }
+        let voices: (typeof portuguese)[] = []
+        let voicesChanged: (() => void) | undefined
+        const synthesis = {
+            getVoices: vi.fn(() => voices),
+            speak: vi.fn((utterance: { onend?: () => void }) =>
+                utterance.onend?.(),
+            ),
+            cancel: vi.fn(),
+            addEventListener: vi.fn(
+                (_type: 'voiceschanged', listener: () => void) => {
+                    voicesChanged = listener
+                },
+            ),
+        }
+        const output = createWebSpeechOutput(synthesis, (text) => ({ text }))
+        voices = [portuguese]
+        voicesChanged?.()
+
+        await expect(
+            output.speak({
+                text: 'Mensagem',
+                locale: 'pt-BR',
+                purpose: 'status',
+                voicePreference: 'default',
+                rate: 1,
+                pitch: 1,
+                volume: 1,
+            }),
+        ).resolves.toBe('completed')
+        expect(synthesis.addEventListener).toHaveBeenCalledWith(
+            'voiceschanged',
+            expect.any(Function),
+        )
+    })
 })

--- a/tests/contracts/web-speech-output.test.ts
+++ b/tests/contracts/web-speech-output.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { createWebSpeechOutput } from '../../src/feedback/public'
+
+describe('Web Speech output', () => {
+    test('speaks canonical text with purpose and portable voice preferences', async () => {
+        const exactRemote = {
+            name: 'Remote Portuguese',
+            lang: 'pt-BR',
+            default: true,
+            localService: false,
+        }
+        const exactLocal = {
+            name: 'Local Portuguese',
+            lang: 'pt-BR',
+            default: false,
+            localService: true,
+        }
+        const speak = vi.fn((utterance: { onend?: () => void }) =>
+            utterance.onend?.(),
+        )
+        const synthesis = {
+            getVoices: () => [exactRemote, exactLocal],
+            speak,
+            cancel: vi.fn(),
+        }
+        const output = createWebSpeechOutput(synthesis, (text) => ({ text }))
+
+        const result = await output.speak({
+            text: 'Captura de acordes ativada.',
+            locale: 'pt-BR',
+            purpose: 'status',
+            voicePreference: 'local',
+            rate: 1.2,
+            pitch: 0.9,
+            volume: 0.8,
+        })
+
+        expect(result).toBe('completed')
+        expect(speak).toHaveBeenCalledWith(
+            expect.objectContaining({
+                text: 'Captura de acordes ativada.',
+                lang: 'pt-BR',
+                voice: exactLocal,
+                rate: 1.2,
+                pitch: 0.9,
+                volume: 0.8,
+            }),
+        )
+    })
+
+    test('falls back to the base language and reports unavailable explicitly', async () => {
+        const portuguese = {
+            name: 'Portuguese',
+            lang: 'pt-PT',
+            default: true,
+            localService: true,
+        }
+        const synthesis = {
+            getVoices: () => [portuguese],
+            speak: vi.fn((utterance: { onend?: () => void }) =>
+                utterance.onend?.(),
+            ),
+            cancel: vi.fn(),
+        }
+        const output = createWebSpeechOutput(synthesis, (text) => ({ text }))
+        const request = {
+            text: 'Mensagem',
+            locale: 'pt-BR',
+            purpose: 'instruction' as const,
+            voicePreference: 'default' as const,
+            rate: 1,
+            pitch: 1,
+            volume: 1,
+        }
+
+        expect(await output.speak(request)).toBe('completed')
+        expect(synthesis.speak).toHaveBeenLastCalledWith(
+            expect.objectContaining({ voice: portuguese }),
+        )
+
+        synthesis.getVoices = () => []
+        expect(await output.speak(request)).toBe('unavailable')
+    })
+
+    test('cancels current speech through the platform seam', () => {
+        const voice = {
+            name: 'Portuguese',
+            lang: 'pt-BR',
+            default: true,
+            localService: true,
+        }
+        const synthesis = {
+            getVoices: () => [voice],
+            speak: vi.fn(),
+            cancel: vi.fn(),
+        }
+        const output = createWebSpeechOutput(synthesis, (text) => ({ text }))
+
+        const completion = output.speak({
+            text: 'Mensagem',
+            locale: 'pt-BR',
+            purpose: 'status',
+            voicePreference: 'default',
+            rate: 1,
+            pitch: 1,
+            volume: 1,
+        })
+        output.cancel()
+
+        expect(synthesis.cancel).toHaveBeenCalledOnce()
+        return expect(completion).resolves.toBe('cancelled')
+    })
+})

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -300,6 +300,103 @@ test('Free Mode speaks canonical feedback and lets the user repeat or stop it', 
     expect(typewriter).toHaveFocus()
 })
 
+test('Free Mode controls speech after capture loses focus and stops on exit', () => {
+    class UtteranceStub {
+        lang = ''
+        rate = 1
+        pitch = 1
+        volume = 1
+        onend?: () => void
+        onerror?: (event: { error?: string }) => void
+
+        constructor(public text: string) {}
+    }
+    const voice = {
+        name: 'Português local',
+        lang: 'pt-BR',
+        default: true,
+        localService: true,
+    }
+    const synthesis = {
+        getVoices: vi.fn(() => [voice]),
+        speak: vi.fn(),
+        cancel: vi.fn(),
+    }
+    vi.stubGlobal('SpeechSynthesisUtterance', UtteranceStub)
+    vi.stubGlobal('speechSynthesis', synthesis)
+    const defaults = createDefaultSimulatorPreferences()
+    globalThis.localStorage.setItem(
+        simulatorPreferencesStorageKey,
+        JSON.stringify({
+            ...defaults,
+            feedback: {
+                ...defaults.feedback,
+                speech: { ...defaults.feedback.speech, enabled: true },
+            },
+        }),
+    )
+    const rendered = renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    act(() => typewriter.focus())
+    fireEvent.blur(typewriter, { relatedTarget: document.body })
+    press(document.body, 'KeyI')
+    expect(synthesis.speak).toHaveBeenCalledWith(
+        expect.objectContaining({
+            text: expect.stringContaining('As teclas F, D, S, J, K e L'),
+        }),
+    )
+
+    press(document.body, 'KeyP')
+    expect(synthesis.cancel).toHaveBeenCalled()
+    const cancellationsBeforeExit = synthesis.cancel.mock.calls.length
+    rendered.unmount()
+    expect(synthesis.cancel).toHaveBeenCalledTimes(cancellationsBeforeExit + 1)
+})
+
+test('O enables automatic reading of produced Braille symbols', () => {
+    class UtteranceStub {
+        lang = ''
+        rate = 1
+        pitch = 1
+        volume = 1
+        onend?: () => void
+        onerror?: (event: { error?: string }) => void
+
+        constructor(public text: string) {}
+    }
+    const synthesis = {
+        getVoices: vi.fn(() => [
+            {
+                name: 'Português',
+                lang: 'pt-BR',
+                default: true,
+                localService: true,
+            },
+        ]),
+        speak: vi.fn((utterance: UtteranceStub) => utterance.onend?.()),
+        cancel: vi.fn(),
+    }
+    vi.stubGlobal('SpeechSynthesisUtterance', UtteranceStub)
+    vi.stubGlobal('speechSynthesis', synthesis)
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    act(() => typewriter.focus())
+    press(typewriter, 'KeyF')
+    expect(synthesis.speak).not.toHaveBeenCalled()
+
+    press(typewriter, 'KeyO')
+    chord(typewriter, ['KeyF', 'KeyD'])
+    expect(synthesis.speak).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'b' }),
+    )
+})
+
 test('Free Mode remains usable when speech and sounds are unavailable', () => {
     vi.stubGlobal('Audio', undefined)
     renderFreeMode()

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -311,8 +311,18 @@ test('Free Mode remains usable when speech and sounds are unavailable', () => {
     press(typewriter, 'KeyM')
     press(typewriter, 'KeyO')
     press(typewriter, 'KeyF')
+    press(typewriter, 'Space')
+    press(typewriter, 'Backspace')
+    chord(typewriter, ['KeyF', 'KeyD'])
+    press(typewriter, 'ArrowRight')
 
-    expect(screen.getByRole('textbox')).toHaveValue('a')
+    expect(screen.getByRole('textbox')).toHaveValue('ab')
+    expect(screen.getByText(/Leitura falada:/)).toHaveTextContent(
+        'Leitura falada: ativada. Sons da máquina: desativados.',
+    )
+    expect(
+        screen.getByRole('status', { name: 'Estado da sessão' }),
+    ).toHaveTextContent('revisão: linha 1, coluna 2')
     expect(screen.getByRole('alert')).toHaveTextContent(
         'A leitura falada está indisponível; o texto e as mensagens acessíveis continuam ativos.',
     )

--- a/tests/journeys/free-mode.test.tsx
+++ b/tests/journeys/free-mode.test.tsx
@@ -45,13 +45,21 @@ const chord = (target: Element, codes: string[]) => {
 const audioEndingWith = (path: string) =>
     AudioStub.instances.find((audio) => audio.src.endsWith(path))
 
+const machineKeyAudio = () =>
+    AudioStub.instances.find((audio) =>
+        audio.src.includes('assets/audio/keys/key-pressed-'),
+    )
+
 beforeEach(() => {
     AudioStub.instances = []
     globalThis.Audio = AudioStub as unknown as typeof Audio
     globalThis.localStorage.clear()
 })
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+})
 
 test('Modo livre digita pelo teclado focado sem criar outra fonte de verdade', async () => {
     renderFreeMode()
@@ -79,11 +87,6 @@ test('Modo livre digita pelo teclado focado sem criar outra fonte de verdade', a
     expect(output).toHaveValue('ab_\n^')
     expect(output).toHaveAttribute('readonly')
     expect(output).not.toHaveClass('braille')
-    await waitFor(() => {
-        expect(
-            audioEndingWith('instrucoes-modo-livre.mp3')?.play,
-        ).toHaveBeenCalled()
-    })
 })
 
 test('Modo livre interrompe acorde incompleto e permite pausar a captura', () => {
@@ -138,14 +141,10 @@ test('Free Mode preserves presentation preferences between typing sessions', asy
     fireEvent.focus(secondTypewriter)
     press(secondTypewriter, 'KeyO')
     press(secondTypewriter, 'KeyM')
+    press(secondTypewriter, 'KeyF')
 
     await waitFor(() => {
-        expect(
-            audioEndingWith('conversor-desmutado.mp3')?.play,
-        ).toHaveBeenCalled()
-        expect(
-            audioEndingWith('teclado-desmutado.mp3')?.play,
-        ).toHaveBeenCalled()
+        expect(machineKeyAudio()?.play).toHaveBeenCalled()
     })
 })
 
@@ -242,4 +241,80 @@ test('Free Mode preserves every important fact from an interrupted chord', () =>
     expect(accessibleFeedback).toHaveTextContent(
         'Captura interrompida porque a área de digitação perdeu o foco; o acorde incompleto foi descartado.',
     )
+})
+
+test('Free Mode speaks canonical feedback and lets the user repeat or stop it', () => {
+    class UtteranceStub {
+        lang = ''
+        voice: unknown
+        rate = 1
+        pitch = 1
+        volume = 1
+        onend?: () => void
+        onerror?: (event: { error?: string }) => void
+
+        constructor(public text: string) {}
+    }
+    const voice = {
+        name: 'Português local',
+        lang: 'pt-BR',
+        default: true,
+        localService: true,
+    }
+    const synthesis = {
+        getVoices: vi.fn(() => [voice]),
+        speak: vi.fn((utterance: UtteranceStub) => utterance.onend?.()),
+        cancel: vi.fn(),
+    }
+    vi.stubGlobal('SpeechSynthesisUtterance', UtteranceStub)
+    vi.stubGlobal('speechSynthesis', synthesis)
+    const defaults = createDefaultSimulatorPreferences()
+    globalThis.localStorage.setItem(
+        simulatorPreferencesStorageKey,
+        JSON.stringify({
+            ...defaults,
+            feedback: {
+                ...defaults.feedback,
+                speech: { ...defaults.feedback.speech, enabled: true },
+            },
+        }),
+    )
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    act(() => typewriter.focus())
+
+    expect(synthesis.speak).toHaveBeenCalledWith(
+        expect.objectContaining({
+            text: 'Captura de acordes ativada.',
+            lang: 'pt-BR',
+            voice,
+        }),
+    )
+    press(typewriter, 'KeyR')
+    expect(synthesis.speak).toHaveBeenCalledTimes(2)
+    press(typewriter, 'KeyP')
+    expect(synthesis.cancel).toHaveBeenCalledOnce()
+    expect(typewriter).toHaveFocus()
+})
+
+test('Free Mode remains usable when speech and sounds are unavailable', () => {
+    vi.stubGlobal('Audio', undefined)
+    renderFreeMode()
+    const typewriter = screen.getByRole('region', {
+        name: 'Área de digitação Braille',
+    })
+
+    act(() => typewriter.focus())
+    press(typewriter, 'KeyM')
+    press(typewriter, 'KeyO')
+    press(typewriter, 'KeyF')
+
+    expect(screen.getByRole('textbox')).toHaveValue('a')
+    expect(screen.getByRole('alert')).toHaveTextContent(
+        'A leitura falada está indisponível; o texto e as mensagens acessíveis continuam ativos.',
+    )
+    expect(typewriter).toHaveFocus()
 })


### PR DESCRIPTION
Entrega da #44.

Esta mudança adiciona Leitura falada do aplicativo e sons opcionais ao Modo livre por adapters substituíveis. Também substitui as gravações de mensagens e instruções pela Web Speech, preservando MP3 apenas para efeitos mecânicos.

Principais mudanças:

- Coordena fala, sons, interrupção e repetição pelo Feedback multimodal.
- Mantém os atalhos I, O, P, R e M disponíveis mesmo após a captura perder o foco.
- Interrompe as saídas ao sair da experiência e evita falas concorrentes.
- Faz O controlar a leitura automática das celas produzidas.
- Pronuncia espaços e caracteres acentuados de forma inequívoca.
- Mantém a jornada utilizável quando áudio ou Web Speech estão indisponíveis.
- Documenta que a voz Web Speech da Alpha 2 ainda exige uma melhoria substancial.

Validação:

- `npm run ci` aprovado.
- 124 testes Vitest e 30 testes das automações aprovados.
- Validação manual aprovada em Linux.
- Permanecem isoladas as quatro falhas de lint herdadas.

Limitações e evoluções registradas:

- #77: interface para velocidade, pitch, volume e demais preferências.
- #80: motor de voz em português mais natural e consistente.
- #81: leitura navegável por caractere, palavra, linha e documento.

Closes #44
